### PR TITLE
Added k8s-bench

### DIFF
--- a/k8s-bench/.gitignore
+++ b/k8s-bench/.gitignore
@@ -1,0 +1,17 @@
+# Binary
+k8s-bench
+
+# Log files
+*.log
+trace.log
+
+# IDE specific files
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# Go specific
+*.test
+*.out
+/vendor/ 

--- a/k8s-bench/README.md
+++ b/k8s-bench/README.md
@@ -1,0 +1,31 @@
+## k8s-bench
+
+`k8s-bench` is a benchmark for assessing the performance of LLM models for kubernetes related tasks.
+
+
+### Usage
+
+```sh
+
+# build the k8s-bench binary
+go build
+
+# evaluate model performance for scale related tasks
+./k8s-bench --agent-bin <path/to/kubectl-ai/binary> --task-pattern scale --kubeconfig <path/to/kubeconfig>
+```
+
+Running the benchmark will produce results as below:
+
+```sh
+Evaluation Results:
+==================
+
+Task: scale-deployment
+  Provider: gemini
+    gemini-2.0-flash-thinking-exp-01-21: true
+
+Task: scale-down-deployment
+  Provider: gemini
+    gemini-2.0-flash-thinking-exp-01-21: true
+
+```

--- a/k8s-bench/eval.go
+++ b/k8s-bench/eval.go
@@ -1,0 +1,162 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v2"
+)
+
+func runEvaluation(config EvalConfig) error {
+	tasks, err := loadTasks(config)
+	if err != nil {
+		return fmt.Errorf("failed to load tasks: %w", err)
+	}
+
+	results := make(map[string]map[string]map[string]bool) // task -> provider -> model -> success
+
+	for taskID, task := range tasks {
+		fmt.Printf("Evaluating task: %s\n", taskID)
+
+		// Run setup if specified
+		if task.Setup != "" {
+			setupPath := filepath.Join(config.TasksDir, taskID, task.Setup)
+			if err := runScript(setupPath, config.KubeConfig); err != nil {
+				return fmt.Errorf("setup failed for task %s: %w", taskID, err)
+			}
+		}
+
+		for _, provider := range config.LLMProviders {
+			results[taskID] = make(map[string]map[string]bool)
+			results[taskID][provider] = make(map[string]bool)
+
+			for _, model := range config.Models[provider] {
+				success, err := evaluateTask(config, taskID, task, provider, model)
+				if err != nil {
+					fmt.Printf("Error evaluating task %s with %s/%s: %v\n", taskID, provider, model, err)
+					results[taskID][provider][model] = false
+					continue
+				}
+				results[taskID][provider][model] = success
+			}
+		}
+	}
+
+	printResults(results)
+	return nil
+}
+
+func loadTasks(config EvalConfig) (map[string]Task, error) {
+	tasks := make(map[string]Task)
+
+	entries, err := os.ReadDir(config.TasksDir)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+
+		taskID := entry.Name()
+		if config.TaskPattern != "" && !strings.Contains(taskID, config.TaskPattern) {
+			continue
+		}
+
+		taskFile := filepath.Join(config.TasksDir, taskID, "task.yaml")
+
+		data, err := os.ReadFile(taskFile)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read task file %s: %w", taskFile, err)
+		}
+
+		var task Task
+		if err := yaml.Unmarshal(data, &task); err != nil {
+			return nil, fmt.Errorf("failed to parse task file %s: %w", taskFile, err)
+		}
+
+		// Skip disabled tasks
+		if task.Disabled {
+			fmt.Printf("Skipping disabled task: %s\n", taskID)
+			continue
+		}
+
+		tasks[taskID] = task
+	}
+
+	return tasks, nil
+}
+
+func evaluateTask(config EvalConfig, taskID string, task Task, provider, model string) (bool, error) {
+	// Run kuba
+	cmd := exec.Command(config.AgentBin,
+		"--kubeconfig", config.KubeConfig,
+		"--query", task.Goal,
+		"--llm-provider", provider,
+		"--model", model,
+	)
+
+	cmd.Env = append(os.Environ(), fmt.Sprintf("KUBECONFIG=%s", config.KubeConfig))
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	fmt.Printf("\nRunning kuba for task %s with %s/%s\n", taskID, provider, model)
+
+	if err := cmd.Run(); err != nil {
+		return false, fmt.Errorf("kuba failed: %w", err)
+	}
+
+	success := true
+	// Run verifier if specified
+	if task.Verifier != "" {
+		verifierPath := filepath.Join(config.TasksDir, taskID, task.Verifier)
+		cmd = exec.Command(verifierPath)
+		cmd.Env = append(os.Environ(), fmt.Sprintf("KUBECONFIG=%s", config.KubeConfig))
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		fmt.Printf("\nRunning verifier for task %s\n", taskID)
+
+		err := cmd.Run()
+		success = err == nil
+		if !success {
+			fmt.Printf("Verifier failed with error: %v\n", err)
+		}
+	}
+
+	// Run cleanup if specified
+	if task.Cleanup != "" {
+		cleanupPath := filepath.Join(config.TasksDir, taskID, task.Cleanup)
+		if err := runScript(cleanupPath, config.KubeConfig); err != nil {
+			fmt.Printf("Warning: cleanup failed for task %s: %v\n", taskID, err)
+		}
+	}
+
+	return success, nil
+}
+
+func runScript(path string, kubeconfig string) error {
+	cmd := exec.Command(path)
+	cmd.Env = append(os.Environ(), fmt.Sprintf("KUBECONFIG=%s", kubeconfig))
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	fmt.Printf("\nRunning script: %s\n", path)
+	return cmd.Run()
+}
+
+func printResults(results map[string]map[string]map[string]bool) {
+	fmt.Println("\nEvaluation Results:")
+	fmt.Println("==================")
+
+	for taskID, providerResults := range results {
+		fmt.Printf("\nTask: %s\n", taskID)
+		for provider, modelResults := range providerResults {
+			fmt.Printf("  Provider: %s\n", provider)
+			for model, success := range modelResults {
+				fmt.Printf("    %s: %v\n", model, success)
+			}
+		}
+	}
+}

--- a/k8s-bench/go.mod
+++ b/k8s-bench/go.mod
@@ -1,0 +1,5 @@
+module github.com/GoogleCloudPlatform/kubectl-ai/k8s-bench
+
+go 1.23.4
+
+require gopkg.in/yaml.v2 v2.4.0

--- a/k8s-bench/go.sum
+++ b/k8s-bench/go.sum
@@ -1,0 +1,4 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=

--- a/k8s-bench/main.go
+++ b/k8s-bench/main.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"flag"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type Task struct {
+	Goal       string `yaml:"goal"`
+	Setup      string `yaml:"setup,omitempty"`
+	Verifier   string `yaml:"verifier,omitempty"`
+	Cleanup    string `yaml:"cleanup,omitempty"`
+	Difficulty string `yaml:"difficulty"`
+	Disabled   bool   `yaml:"disabled,omitempty"`
+}
+
+type EvalConfig struct {
+	LLMProviders []string
+	Models       map[string][]string // provider -> list of models
+	KubeConfig   string
+	TasksDir     string
+	TaskPattern  string
+	AgentBin     string
+}
+
+func expandPath(path string) (string, error) {
+	if strings.HasPrefix(path, "~/") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		path = filepath.Join(home, path[2:])
+	}
+	return filepath.Clean(os.ExpandEnv(path)), nil
+}
+
+func main() {
+	tasksDir := flag.String("tasks-dir", "./tasks", "Directory containing evaluation tasks")
+	kubeconfig := flag.String("kubeconfig", "", "Path to kubeconfig file")
+	taskPattern := flag.String("task-pattern", "", "Pattern to filter tasks (e.g. 'pod' or 'redis')")
+	agentBin := flag.String("agent-bin", "", "Path to kubernetes agent binary")
+	llmProvider := flag.String("llm-provider", "gemini", "Specific LLM provider to evaluate (e.g. 'gemini' or 'ollama')")
+	modelList := flag.String("models", "", "Comma-separated list of models to evaluate (e.g. 'gemini-1.0,gemini-2.0')")
+	flag.Parse()
+
+	if *kubeconfig == "" {
+		log.Fatal("--kubeconfig is required")
+	}
+
+	expandedKubeconfig, err := expandPath(*kubeconfig)
+	if err != nil {
+		log.Fatalf("Failed to expand kubeconfig path: %v", err)
+	}
+
+	providers := []string{"gemini", "ollama"}
+	if *llmProvider != "" {
+		providers = []string{*llmProvider}
+	}
+
+	defaultModels := map[string][]string{
+		"gemini": {"gemini-2.0-flash-thinking-exp-01-21"},
+	}
+
+	models := defaultModels
+	if *modelList != "" {
+		if *llmProvider == "" {
+			log.Fatal("--llm-provider is required when --models is specified")
+		}
+		modelSlice := strings.Split(*modelList, ",")
+		models = map[string][]string{
+			*llmProvider: modelSlice,
+		}
+	}
+
+	config := EvalConfig{
+		LLMProviders: providers,
+		Models:       models,
+		KubeConfig:   expandedKubeconfig,
+		TasksDir:     *tasksDir,
+		TaskPattern:  *taskPattern,
+		AgentBin:     *agentBin,
+	}
+
+	if err := runEvaluation(config); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/k8s-bench/tasks/configure-ingress/cleanup.sh
+++ b/k8s-bench/tasks/configure-ingress/cleanup.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+kubectl delete namespace ingress-test 

--- a/k8s-bench/tasks/configure-ingress/setup.sh
+++ b/k8s-bench/tasks/configure-ingress/setup.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Create namespace and deploy a test application
+kubectl create namespace ingress-test
+
+# Create deployment and service
+kubectl create deployment web-app --image=nginx -n ingress-test
+kubectl expose deployment web-app --name=web-service --port=80 -n ingress-test
+
+# Wait for deployment to be ready
+for i in {1..30}; do
+    if kubectl get deployment web-app -n ingress-test -o jsonpath='{.status.availableReplicas}' | grep -q "1"; then
+        exit 0
+    fi
+    sleep 1
+done 

--- a/k8s-bench/tasks/configure-ingress/task.yaml
+++ b/k8s-bench/tasks/configure-ingress/task.yaml
@@ -1,0 +1,6 @@
+goal: "Please create route for routing traffic from path '/app' to service 'web-service' in namespace 'ingress-test'."
+setup: "setup.sh"
+verifier: "verify.sh"
+cleanup: "cleanup.sh"
+# disabled: true
+difficulty: "medium" 

--- a/k8s-bench/tasks/configure-ingress/verify.sh
+++ b/k8s-bench/tasks/configure-ingress/verify.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Wait up to 30 seconds for ingress to be created and configured
+for i in {1..30}; do
+    # Check if ingress exists and has the correct path
+    if kubectl get ingress -n ingress-test -o jsonpath='{.items[*].spec.rules[*].http.paths[*].path}' | grep -q "/app"; then
+        # Check if backend service is correctly configured
+        if kubectl get ingress -n ingress-test -o jsonpath='{.items[*].spec.rules[*].http.paths[*].backend.service.name}' | grep -q "web-service"; then
+            exit 0
+        fi
+    fi
+    sleep 1
+done
+
+# If we get here, ingress wasn't configured correctly
+exit 1 

--- a/k8s-bench/tasks/create-pod/cleanup.sh
+++ b/k8s-bench/tasks/create-pod/cleanup.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+kubectl delete pod web-server -n default 

--- a/k8s-bench/tasks/create-pod/task.yaml
+++ b/k8s-bench/tasks/create-pod/task.yaml
@@ -1,0 +1,4 @@
+goal: "Please create a nginx pod named web-server in the default namespace"
+verifier: "verify.sh"
+cleanup: "cleanup.sh"
+difficulty: "easy" 

--- a/k8s-bench/tasks/create-pod/verify.sh
+++ b/k8s-bench/tasks/create-pod/verify.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Wait up to 30 seconds for pod to be running
+for i in {1..30}; do
+    if kubectl get pod web-server -n default -o jsonpath='{.status.phase}' | grep -q "Running"; then
+        exit 0
+    fi
+    sleep 1
+done
+
+# If we get here, pod didn't reach Running state in time
+exit 1 

--- a/k8s-bench/tasks/fix-crashloop/cleanup.sh
+++ b/k8s-bench/tasks/fix-crashloop/cleanup.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+kubectl delete namespace crashloop-test 

--- a/k8s-bench/tasks/fix-crashloop/setup.sh
+++ b/k8s-bench/tasks/fix-crashloop/setup.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Create namespace and a deployment with an invalid command that will cause crashloop
+kubectl create namespace crashloop-test
+cat <<EOF | kubectl apply -f -
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app
+  namespace: crashloop-test
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx
+        command: ["/bin/sh", "-c"]
+        args: ["nonexistent_command"]  # This will cause the pod to crash
+EOF
+
+# Wait for pod to enter crashloop state
+for i in {1..30}; do
+    if kubectl get pods -n crashloop-test -l app=nginx -o jsonpath='{.items[0].status.containerStatuses[0].restartCount}' | grep -q "[1-9]"; then
+        exit 0
+    fi
+    sleep 1
+done 

--- a/k8s-bench/tasks/fix-crashloop/task.yaml
+++ b/k8s-bench/tasks/fix-crashloop/task.yaml
@@ -1,0 +1,6 @@
+goal: "Please fix the error in the deployment named 'app' in namespace 'crashloop-test'"
+setup: "setup.sh"
+verifier: "verify.sh"
+cleanup: "cleanup.sh"
+# disabled: true
+difficulty: "medium" 

--- a/k8s-bench/tasks/fix-crashloop/verify.sh
+++ b/k8s-bench/tasks/fix-crashloop/verify.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Wait up to 30 seconds for deployment's pod to be running and stable
+for i in {1..30}; do
+    # Check if deployment's pod is running and hasn't restarted in the last check
+    status=$(kubectl get pods -n crashloop-test -l app=nginx -o jsonpath='{.items[0].status.phase}')
+    restarts=$(kubectl get pods -n crashloop-test -l app=nginx -o jsonpath='{.items[0].status.containerStatuses[0].restartCount}')
+    
+    if [[ "$status" == "Running" ]]; then
+        # Wait additional 5 seconds to ensure stability
+        sleep 5
+        new_restarts=$(kubectl get pods -n crashloop-test -l app=nginx -o jsonpath='{.items[0].status.containerStatuses[0].restartCount}')
+        if [[ "$restarts" == "$new_restarts" ]]; then
+            exit 0
+        fi
+    fi
+    sleep 1
+done
+
+# If we get here, deployment's pod didn't stabilize in time
+exit 1 

--- a/k8s-bench/tasks/fix-image-pull/cleanup.sh
+++ b/k8s-bench/tasks/fix-image-pull/cleanup.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+kubectl delete namespace debug 

--- a/k8s-bench/tasks/fix-image-pull/setup.sh
+++ b/k8s-bench/tasks/fix-image-pull/setup.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Create namespace and a deployment with an invalid image that will cause ImagePullBackOff
+kubectl create namespace debug
+cat <<EOF | kubectl apply -f -
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app
+  namespace: debug
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:invalid-tag  # This will cause ImagePullBackOff error
+EOF
+
+# Wait for deployment's pod to enter ImagePullBackOff state
+for i in {1..30}; do
+    if kubectl get pods -n debug -l app=nginx -o jsonpath='{.items[0].status.containerStatuses[0].state.waiting.reason}' | grep -q "ImagePullBackOff"; then
+        exit 0
+    fi
+    sleep 1
+done 

--- a/k8s-bench/tasks/fix-image-pull/task.yaml
+++ b/k8s-bench/tasks/fix-image-pull/task.yaml
@@ -1,0 +1,5 @@
+goal: "Please fix the error in the deployment named 'app' in namespace 'debug'"
+setup: "setup.sh"
+verifier: "verify.sh"
+cleanup: "cleanup.sh"
+difficulty: "medium" 

--- a/k8s-bench/tasks/fix-image-pull/verify.sh
+++ b/k8s-bench/tasks/fix-image-pull/verify.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Wait up to 30 seconds for pod to be running and stable
+for i in {1..30}; do
+    # Check if pod is running and hasn't restarted in the last check
+    status=$(kubectl get pods -n debug -l app=nginx -o jsonpath='{.items[0].status.phase}')
+    restarts=$(kubectl get pods -n debug -l app=nginx -o jsonpath='{.items[0].status.containerStatuses[0].restartCount}')
+    
+    if [[ "$status" == "Running" ]]; then
+        # Wait additional 5 seconds to ensure stability
+        sleep 5
+        new_restarts=$(kubectl get pods -n debug -l app=nginx -o jsonpath='{.items[0].status.containerStatuses[0].restartCount}')
+        if [[ "$restarts" == "$new_restarts" ]]; then
+            exit 0
+        fi
+    fi
+    sleep 1
+done
+
+# If we get here, pod didn't stabilize in time
+exit 1 

--- a/k8s-bench/tasks/fix-service-routing/cleanup.sh
+++ b/k8s-bench/tasks/fix-service-routing/cleanup.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+kubectl delete namespace web 

--- a/k8s-bench/tasks/fix-service-routing/setup.sh
+++ b/k8s-bench/tasks/fix-service-routing/setup.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Create namespace and deployment with one set of labels
+kubectl create namespace web
+
+# Create deployment with label app=nginx
+kubectl create deployment nginx --image=nginx -n web
+# kubectl label deployment nginx -n web app=nginx --overwrite
+
+# Create service with different selector (app=web)
+cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx
+  namespace: web
+spec:
+  ports:
+  - port: 80
+    targetPort: 80
+  selector:
+    app: web  # Mismatched label - deployment has app=nginx
+EOF
+
+# Wait for deployment to be ready
+for i in {1..30}; do
+    if kubectl get deployment nginx -n web -o jsonpath='{.status.availableReplicas}' | grep -q "1"; then
+        exit 0
+    fi
+    sleep 1
+done 

--- a/k8s-bench/tasks/fix-service-routing/task.yaml
+++ b/k8s-bench/tasks/fix-service-routing/task.yaml
@@ -1,0 +1,5 @@
+goal: "Please diagnose and fix why the nginx service in namespace 'web' isn't accessible"
+setup: "setup.sh"
+verifier: "verify.sh"
+cleanup: "cleanup.sh"
+difficulty: "medium" 

--- a/k8s-bench/tasks/fix-service-routing/verify.sh
+++ b/k8s-bench/tasks/fix-service-routing/verify.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Wait up to 30 seconds for service endpoints to be created
+for i in {1..30}; do
+    # Check if service has endpoints
+    endpoints=$(kubectl get endpoints nginx -n web -o jsonpath='{.subsets[0].addresses}')
+    if [[ ! -z "$endpoints" ]]; then
+        # Verify service can access the pod
+        if kubectl run -n web test-connection --image=busybox --restart=Never --rm -i --timeout=10s \
+            -- wget -qO- nginx; then
+            exit 0
+        fi
+    fi
+    sleep 1
+done
+
+# If we get here, service connection failed
+exit 1 

--- a/k8s-bench/tasks/scale-deployment/cleanup.sh
+++ b/k8s-bench/tasks/scale-deployment/cleanup.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+kubectl delete namespace scale-test 

--- a/k8s-bench/tasks/scale-deployment/setup.sh
+++ b/k8s-bench/tasks/scale-deployment/setup.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Create namespace and a deployment with initial replicas
+kubectl create namespace scale-test
+kubectl create deployment web-app --image=nginx --replicas=1 -n scale-test
+# Wait for initial deployment to be ready
+for i in {1..30}; do
+    if kubectl get deployment web-app -n scale-test -o jsonpath='{.status.availableReplicas}' | grep -q "1"; then
+        exit 0
+    fi
+    sleep 1
+done 

--- a/k8s-bench/tasks/scale-deployment/task.yaml
+++ b/k8s-bench/tasks/scale-deployment/task.yaml
@@ -1,0 +1,5 @@
+goal: "Scale up the replicas of deployment 'web-app' in namespace 'scale-test' by 100%"
+setup: "setup.sh"
+verifier: "verify.sh"
+cleanup: "cleanup.sh"
+difficulty: "medium" 

--- a/k8s-bench/tasks/scale-deployment/verify.sh
+++ b/k8s-bench/tasks/scale-deployment/verify.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Wait up to 30 seconds for deployment to scale to 4 replicas
+for i in {1..30}; do
+    if kubectl get deployment web-app -n scale-test -o jsonpath='{.status.availableReplicas}' | grep -q "2"; then
+        exit 0
+    fi
+    sleep 1
+done
+
+# If we get here, deployment didn't scale up in time
+exit 1 

--- a/k8s-bench/tasks/scale-down-deployment/cleanup.sh
+++ b/k8s-bench/tasks/scale-down-deployment/cleanup.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+kubectl delete namespace scale-down-test 

--- a/k8s-bench/tasks/scale-down-deployment/setup.sh
+++ b/k8s-bench/tasks/scale-down-deployment/setup.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Create namespace and a deployment with initial replicas
+kubectl create namespace scale-down-test
+kubectl create deployment web-service --image=nginx --replicas=4 -n scale-down-test
+# Wait for initial deployment to be ready
+for i in {1..30}; do
+    if kubectl get deployment web-service -n scale-down-test -o jsonpath='{.status.availableReplicas}' | grep -q "4"; then
+        exit 0
+    fi
+    sleep 1
+done 

--- a/k8s-bench/tasks/scale-down-deployment/task.yaml
+++ b/k8s-bench/tasks/scale-down-deployment/task.yaml
@@ -1,0 +1,5 @@
+goal: "Scale down the replicas of deployment 'web-service' in namespace 'scale-down-test' by 50%"
+setup: "setup.sh"
+verifier: "verify.sh"
+cleanup: "cleanup.sh"
+difficulty: "medium" 

--- a/k8s-bench/tasks/scale-down-deployment/verify.sh
+++ b/k8s-bench/tasks/scale-down-deployment/verify.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Wait up to 30 seconds for deployment to scale down to 2 replicas
+for i in {1..30}; do
+    if kubectl get deployment web-service -n scale-down-test -o jsonpath='{.status.availableReplicas}' | grep -q "2"; then
+        exit 0
+    fi
+    sleep 1
+done
+
+# If we get here, deployment didn't scale down in time
+exit 1 


### PR DESCRIPTION
Added `k8s-bench`, an evaluation benchmark to assess performance of LLM models for real-world kubernetes tasks. Eval tasks are located under `k8s-bench/tasks/`.

For now, I am using this as an e2e test for `kubectl-ai` agent.


```sh

# build the k8s-bench binary
go build

# evaluate model performance for scale related tasks
./k8s-bench --agent-bin <path/to/kubectl-ai/binary> --task-pattern scale --kubeconfig <path/to/kubeconfig>
```

Running the benchmark will produce results as below:

```sh
Evaluation Results:
==================

Task: scale-deployment
  Provider: gemini
    gemini-2.0-flash-thinking-exp-01-21: true

Task: scale-down-deployment
  Provider: gemini
    gemini-2.0-flash-thinking-exp-01-21: true

```