### PR TITLE
k8sbench: log stdout/stderr to file

### DIFF
--- a/k8s-bench/main.go
+++ b/k8s-bench/main.go
@@ -137,7 +137,7 @@ func run(ctx context.Context) error {
 		}
 	}
 
-	if err := runEvaluation(config); err != nil {
+	if err := runEvaluation(ctx, config); err != nil {
 		return fmt.Errorf("running evaluation: %w", err)
 	}
 


### PR DESCRIPTION
Ensure that k8sbench can log stdout/stderr to a file, so we can see what is going on.

I also moved setup.sh, as otherwise the second run for each scenario is (hopefully) already fixed by the first run. Ironically the LLM seems to do better when we do set up the scenario correctly each time.