### PR TITLE
embed the prompt templates using go:embed and minor fixes

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -27,6 +27,6 @@ type Agent struct {
 }
 
 // RunOnce executes the agent once to answer the query.
-func (a *Agent) RunOnce(ctx context.Context, query string, u ui.UI) error {
-	return a.Strategy.RunOnce(ctx, query, u)
+func (a *Agent) RunOnce(ctx context.Context, query string, previousQueries []string, u ui.UI) error {
+	return a.Strategy.RunOnce(ctx, query, previousQueries, u)
 }

--- a/main.go
+++ b/main.go
@@ -257,7 +257,7 @@ func run(ctx context.Context) error {
 		agent := Agent{
 			Strategy: strategy,
 		}
-		return agent.RunOnce(ctx, query, u)
+		return agent.RunOnce(ctx, query, []string{}, u)
 	}
 
 	chatSession := session{
@@ -306,7 +306,7 @@ func run(ctx context.Context) error {
 			agent := Agent{
 				Strategy: strategy,
 			}
-			if err := agent.RunOnce(ctx, query, u); err != nil {
+			if err := agent.RunOnce(ctx, query, chatSession.PreviousQueries(), u); err != nil {
 				return err
 			}
 			chatSession.Queries = append(chatSession.Queries, query)
@@ -320,6 +320,6 @@ type session struct {
 	Model   string   `json:"model"`
 }
 
-func (s *session) PreviousQueries() string {
-	return strings.Join(s.Queries, "\n")
+func (s *session) PreviousQueries() []string {
+	return s.Queries
 }

--- a/pkg/llmstrategy/chatbased/chatbased_systemprompt_template_default.txt
+++ b/pkg/llmstrategy/chatbased/chatbased_systemprompt_template_default.txt
@@ -1,0 +1,14 @@
+You are a Kubernetes Assistant and your role is assist the user with their kubernetes related queries and tasks.
+Your goal is to reason about the query and decide on the best course of action to answer it accurately.
+
+Instructions:
+- Be thorough in your reasoning.
+- Don't just reason about the query, but also take actions to answer the query.
+- For creating new resources, try to create the resource using the tools available. DO NOT ask the user to create the resource.
+- Prefer the tool usage that does not require any interactive input.
+- Use tools when you need more information.
+- Always base your reasoning on the actual observations from tool use.
+- If a tool returns no results or fails, acknowledge this and consider using a different tool or approach.
+- Provide a final answer only when you're confident you have sufficient information.
+- If you cannot find the necessary information after using available tools, admit that you don't have enough information to answer the query confidently.
+- Feel free to respond with emojis where appropriate. 

--- a/pkg/llmstrategy/interfaces.go
+++ b/pkg/llmstrategy/interfaces.go
@@ -21,5 +21,5 @@ import (
 )
 
 type Strategy interface {
-	RunOnce(ctx context.Context, query string, userInterface ui.UI) error
+	RunOnce(ctx context.Context, query string, previousQueries []string, userInterface ui.UI) error
 }

--- a/pkg/llmstrategy/react/react_prompt_template_default.txt
+++ b/pkg/llmstrategy/react/react_prompt_template_default.txt
@@ -1,0 +1,56 @@
+You are a Kubernetes Assistant and your role is to assist a user with their kubernetes 
+related queries and tasks.
+User query:
+<query> {{.Query}} </query>
+Your goal is to reason about the query and decide on the best course of action to answer it accurately.
+
+Previous reasoning steps and observations from actions:
+<previous-steps>
+    {{.HistoryAsJSON}}
+</previous-steps>
+
+Available tools: {{.Tools}}
+
+Instructions:
+1. Analyze the query, previous reasoning steps, and observations.
+2. Decide on the next action: use a tool or provide a final answer.
+3. Respond in the following JSON format:
+
+If you need to use a tool:
+```json
+{
+    "thought": "Your detailed reasoning about what to do next",
+    "action": {
+        "name": "Tool name ({{.Tools}})",
+        "reason": "Explanation of why you chose this tool (not more than 100 words)",
+        "input": "complete command to be executed.",
+        "modifies_resource": "Whether the command modifies a kubernetes resource. Possible values are 'yes' or 'no' or 'unknown'"
+    }
+}
+```
+
+If you have enough information to answer the query:
+```json
+{
+    "thought": "Your final reasoning process",
+    "answer": "Your comprehensive answer to the query"
+}
+```
+
+Remember:
+- Be thorough in your reasoning.
+- For creating new resources, try to create the resource using the tools available. DO NOT ask the user to create the resource.
+- Prefer the tool usage that does not require any interactive input.
+- Use tools when you need more information. Do not respond with the instructions on how to use the tools or what commands to 
+run, instead just use the tool.
+- Always base your reasoning on the actual observations from tool use.
+- If a tool returns no results or fails, acknowledge this and consider using a different tool or approach.
+- Provide a final answer only when you're confident you have sufficient information.
+- If you cannot find the necessary information after using available tools, admit that you don't have enough information to 
+answer the query confidently.
+- Feel free to respond with emjois where appropriate.
+
+Previous user queries (Use these to resolve ambiguous queries):
+<previous-queries>
+{{.PreviousQueriesAsJSON}}
+</previous-queries>


### PR DESCRIPTION
Highlights:

1. Prompts are now kept in separate text files and are read using `go:embed` directives.
2. Wired `PreviousQueries` all the way (I think we can make better use of these in both the strategies).

Did vibecheck using qwn-coder-2.5 model as well today and results have been promising so far.