### PR TITLE
kubectl runner handles input command correctly

### DIFF
--- a/pkg/llmstrategy/react/react_prompt_template_default.txt
+++ b/pkg/llmstrategy/react/react_prompt_template_default.txt
@@ -22,8 +22,8 @@ If you need to use a tool:
     "thought": "Your detailed reasoning about what to do next",
     "action": {
         "name": "Tool name ({{.Tools}})",
-        "reason": "Explanation of why you chose this tool (not more than 100 words)",
-        "input": "complete command to be executed.",
+        "reason": "Explanation of why you chosse this tool (not more than 100 words)",
+        "command": "Complete command to be executed. For example, 'kubectl get pods', 'kubectl get ns'",
         "modifies_resource": "Whether the command modifies a kubernetes resource. Possible values are 'yes' or 'no' or 'unknown'"
     }
 }

--- a/pkg/llmstrategy/react/strategy.go
+++ b/pkg/llmstrategy/react/strategy.go
@@ -102,16 +102,16 @@ func (a *Strategy) RunOnce(ctx context.Context, query string, previousQueries []
 			log.Info("Executing action",
 				"name", reActResp.Action.Name,
 				"reason", reActResp.Action.Reason,
-				"input", reActResp.Action.Input,
+				"command", reActResp.Action.Command,
 				"modifies_resource", reActResp.Action.ModifiesResource,
 			)
 
 			// Sanitize and prepare action
-			reActResp.Action.Input = sanitizeToolInput(reActResp.Action.Input)
-			a.addMessage(ctx, "user", fmt.Sprintf("Action: %q", reActResp.Action.Input))
+			reActResp.Action.Command = sanitizeToolInput(reActResp.Action.Command)
+			a.addMessage(ctx, "user", fmt.Sprintf("Action: %q", reActResp.Action.Command))
 
 			// Display action details
-			u.RenderOutput(ctx, fmt.Sprintf("  Running: %s", reActResp.Action.Input), ui.Foreground(ui.ColorGreen))
+			u.RenderOutput(ctx, fmt.Sprintf("  Running: %s", reActResp.Action.Command), ui.Foreground(ui.ColorGreen))
 			u.RenderOutput(ctx, reActResp.Action.Reason, ui.RenderMarkdown())
 
 			if a.AsksForConfirmation && reActResp.Action.ModifiesResource == "yes" {
@@ -123,14 +123,14 @@ func (a *Strategy) RunOnce(ctx context.Context, query string, previousQueries []
 			}
 
 			// Execute action
-			output, err := a.executeAction(ctx, reActResp.Action.Name, reActResp.Action.Input, workDir)
+			output, err := a.executeAction(ctx, reActResp.Action.Name, reActResp.Action.Command, workDir)
 			if err != nil {
 				log.Error(err, "Error executing action")
 				return err
 			}
 
 			// Record observation
-			observation := fmt.Sprintf("Output of %q:\n%s", reActResp.Action.Input, output)
+			observation := fmt.Sprintf("Output of %q:\n%s", reActResp.Action.Command, output)
 			a.addMessage(ctx, "user", observation)
 		}
 
@@ -252,7 +252,7 @@ type ReActResponse struct {
 type Action struct {
 	Name             string `json:"name"`
 	Reason           string `json:"reason"`
-	Input            string `json:"input"`
+	Command          string `json:"command"`
 	ModifiesResource string `json:"modifies_resource"`
 }
 

--- a/tools_test.go
+++ b/tools_test.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"testing"
+)
+
+func TestKubectlRunner(t *testing.T) {
+
+	testCases := []struct {
+		command             string
+		expected            string
+		expectedErr         error
+		expectedFile        string
+		expectedFileContent string
+	}{
+		// {
+		// 	command: "kubectl get pods",
+		// 	expected:    "pods",
+		// 	expectedErr: nil,
+		// },
+		{
+			command:     "kubectl edit pods",
+			expected:    "interactive mode not supported for kubectl, please use non-interactive commands",
+			expectedErr: errors.New("interactive mode not supported for kubectl, please use non-interactive commands"),
+		},
+		{
+
+			command: `cat <<EOF > ingress.yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+ name: web-ingress
+ namespace: ingress-test
+spec:
+ rules:
+ - host: "example.com" # Replace with your desired hostname
+   http:
+     paths:
+     - path: /app
+       pathType: Prefix
+       backend:
+         service:
+           name: web-service
+           port:
+             number: 80
+EOF`,
+			// expected:    "",
+			expectedErr:  nil,
+			expectedFile: "ingress.yaml",
+			expectedFileContent: `apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+ name: web-ingress
+ namespace: ingress-test
+spec:
+ rules:
+ - host: "example.com" # Replace with your desired hostname
+   http:
+     paths:
+     - path: /app
+       pathType: Prefix
+       backend:
+         service:
+           name: web-service
+           port:
+             number: 80
+`,
+		},
+		{
+			command: `kubectl apply -f - <<EOF
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: web-ingress
+spec:
+  rules:
+  - host: "example.com" # Replace with your desired hostname
+    http:
+      paths:
+      - path: /app
+        pathType: Prefix
+        backend:
+          service:
+            name: web-service
+            port:
+              number: 80
+EOF`,
+			expected:    "",
+			expectedErr: nil,
+		},
+	}
+
+	for _, testCase := range testCases {
+		kubeconfig := ""
+		workDir := ""
+
+		output, err := kubectlRunner(testCase.command, kubeconfig, workDir)
+		t.Logf("Output: %s", output)
+		if err != nil {
+			if testCase.expectedErr == nil {
+				t.Errorf("Expected no error, but got: %v", err)
+			} else if err.Error() != testCase.expectedErr.Error() {
+				t.Errorf("Expected error: %v, but got: %v", testCase.expectedErr, err)
+			}
+		}
+		if output != testCase.expected {
+			t.Errorf("Expected output: %s, but got: %s", testCase.expected, output)
+		}
+		if testCase.expectedFile != "" {
+			if _, err := os.Stat(testCase.expectedFile); os.IsNotExist(err) {
+				t.Errorf("Expected file: %s, but it does not exist", testCase.expectedFile)
+			}
+			content, err := os.ReadFile(testCase.expectedFile)
+			if err != nil {
+				t.Errorf("Error reading file: %v", err)
+			}
+			if string(content) != testCase.expectedFileContent {
+				t.Errorf("Expected file content: %s, but got: %s", testCase.expectedFileContent, string(content))
+			}
+		}
+	}
+}


### PR DESCRIPTION
Major bug fix.

kubectl runner was splitting the incoming command into an argument array before passing to `os.Exec` and that was causing commands with multiple lines to be dropped out. This was eliminating very useful commands that involves `here-doc` syntax and `kubectl apply -f -`.

During the POC, I rushed into intercepting `kubectl edit` command and incorrectly handled it. This fix should unlock major performance gains. I am already seeing gemma3 performing super well.