### PR TITLE
Better configuration loading

### DIFF
--- a/main.go
+++ b/main.go
@@ -98,18 +98,32 @@ func (o *Options) LoadConfiguration(b []byte) error {
 	return nil
 }
 
-func run(ctx context.Context) error {
-	// Command line flags
-	var opt Options
-	opt.InitDefaults()
+func (o *Options) LoadConfigurationFile() error {
+	configPaths := []string{
+		"{CONFIG}/kubectl-ai/config.yaml",
+		"{HOME}/.config/kubectl-ai/config.yaml",
+	}
 
-	{
+	for _, configPath := range configPaths {
 		// Try to load configuration
-		configDir, err := os.UserConfigDir()
-		if err != nil {
-			return fmt.Errorf("getting user config directory: %w", err)
+		tokens := strings.Split(configPath, "/")
+		for i, token := range tokens {
+			if token == "{CONFIG}" {
+				configDir, err := os.UserConfigDir()
+				if err != nil {
+					return fmt.Errorf("getting user config directory: %w", err)
+				}
+				tokens[i] = configDir
+			}
+			if token == "{HOME}" {
+				homeDir, err := os.UserHomeDir()
+				if err != nil {
+					return fmt.Errorf("getting user home directory: %w", err)
+				}
+				tokens[i] = homeDir
+			}
 		}
-		configPath := filepath.Join(configDir, "kubectl-ai", "config.yaml")
+		configPath = filepath.Join(tokens...)
 		configBytes, err := os.ReadFile(configPath)
 		if err != nil {
 			if os.IsNotExist(err) {
@@ -118,9 +132,23 @@ func run(ctx context.Context) error {
 				fmt.Fprintf(os.Stderr, "warning: could not load defaults from %q: %v\n", configPath, err)
 			}
 		}
-		if err := opt.LoadConfiguration(configBytes); err != nil {
-			fmt.Fprintf(os.Stderr, "warning: error loading configuration from %q: %v\n", configPath, err)
+		if len(configBytes) > 0 {
+			if err := o.LoadConfiguration(configBytes); err != nil {
+				fmt.Fprintf(os.Stderr, "warning: error loading configuration from %q: %v\n", configPath, err)
+			}
 		}
+	}
+
+	return nil
+}
+
+func run(ctx context.Context) error {
+	// Command line flags
+	var opt Options
+	opt.InitDefaults()
+
+	if err := opt.LoadConfigurationFile(); err != nil {
+		return fmt.Errorf("loading configuration file: %w", err)
 	}
 
 	maxIterations := flag.Int("max-iterations", 20, "maximum number of iterations agent will try before giving up")


### PR DESCRIPTION
The config directory on MacOS is not ~/.config and is somewhat surprising to me.

Add a multi-path loader and also try loading from ~/.config.
