### PR TITLE
Fixed bug in retrying logic

### DIFF
--- a/gollm/interfaces.go
+++ b/gollm/interfaces.go
@@ -49,6 +49,9 @@ type Chat interface {
 	// SetFunctionDefinitions configures the set of tools (functions) available to the LLM
 	// for function calling.
 	SetFunctionDefinitions(functionDefinitions []*FunctionDefinition) error
+
+	// IsRetryableError returns true if the error is retryable.
+	IsRetryableError(error) bool
 }
 
 // CompletionRequest is a request to generate a completion for a given prompt.

--- a/gollm/llamacpp.go
+++ b/gollm/llamacpp.go
@@ -263,6 +263,11 @@ func (c *LlamaCppChat) Send(ctx context.Context, contents ...any) (ChatResponse,
 	return llmacppResponse, nil
 }
 
+func (c *LlamaCppChat) IsRetryableError(err error) bool {
+	// TODO(droot): Implement this
+	return false
+}
+
 func ptrTo[T any](t T) *T {
 	return &t
 }

--- a/gollm/ollama.go
+++ b/gollm/ollama.go
@@ -179,6 +179,11 @@ func (c *OllamaChat) Send(ctx context.Context, contents ...any) (ChatResponse, e
 	return ollamaResponse, nil
 }
 
+func (c *OllamaChat) IsRetryableError(err error) bool {
+	// TODO(droot): Implement this
+	return false
+}
+
 type OllamaChatResponse struct {
 	candidates     []*OllamaCandidate
 	ollamaResponse api.ChatResponse

--- a/gollm/vertexai.go
+++ b/gollm/vertexai.go
@@ -193,6 +193,11 @@ type VertexAIChat struct {
 	chat  *genai.ChatSession
 }
 
+func (c *VertexAIChat) IsRetryableError(err error) bool {
+	// TODO(droot): Implement this
+	return false
+}
+
 // SetFunctionDefinitions sets the function definitions for the chat.
 // This allows the LLM to call user-defined functions.
 func (c *VertexAIChat) SetFunctionDefinitions(functionDefinitions []*FunctionDefinition) error {

--- a/pkg/agent/conversation.go
+++ b/pkg/agent/conversation.go
@@ -87,11 +87,12 @@ func (s *Conversation) Init(ctx context.Context, u ui.UI) error {
 		s.LLM.StartChat(systemPrompt, s.Model),
 		gollm.RetryConfig{
 			MaxAttempts:    3,
-			InitialBackoff: 1 * time.Second,
-			MaxBackoff:     10 * time.Second,
+			InitialBackoff: 10 * time.Second,
+			MaxBackoff:     60 * time.Second,
 			BackoffFactor:  2,
 			Jitter:         true,
-		}, gollm.DefaultIsRetryableError)
+		},
+	)
 
 	if !s.EnableToolUseShim {
 		var functionDefinitions []*gollm.FunctionDefinition
@@ -149,7 +150,6 @@ func (a *Conversation) RunOneRound(ctx context.Context, query string) error {
 
 		response, err := a.llmChat.Send(ctx, currChatContent...)
 		if err != nil {
-			log.Error(err, "Error sending initial message")
 			return err
 		}
 
@@ -162,7 +162,6 @@ func (a *Conversation) RunOneRound(ctx context.Context, query string) error {
 		currChatContent = nil
 
 		if len(response.Candidates()) == 0 {
-			log.Error(nil, "No candidates in response")
 			return fmt.Errorf("no candidates in LLM response")
 		}
 
@@ -172,7 +171,6 @@ func (a *Conversation) RunOneRound(ctx context.Context, query string) error {
 			// convert the candidate response into a gollm.ChatResponse
 			candidate, err = candidateToShimCandidate(candidate)
 			if err != nil {
-				log.Error(err, "Failed to convert candidate to shim candidate")
 				return err
 			}
 		}


### PR DESCRIPTION
Realized I had a bug in the retry logic in the way we detect if error is retryable. 

There are more improvements I want to but will keep it for later PRs. For example (take the feedback from the API about backoff delay) and some minor improvements for other providers. Overall, this is working pretty nicely especially today got lots of 429 errors for `gemini-2.5-pro-experimental`.