### PR TITLE
Toggled ask-for-configuration defaults to confirm by default

### DIFF
--- a/k8s-bench/eval.go
+++ b/k8s-bench/eval.go
@@ -312,6 +312,7 @@ func (x *TaskExecution) runAgent(ctx context.Context) error {
 		fmt.Sprintf("--enable-tool-use-shim=%t", x.llmConfig.EnableToolUseShim),
 		"--model", x.llmConfig.ModelID,
 		"--trace-path", tracePath,
+		"--skip-permissions",
 	}
 
 	stdinReader, stdinWriter := io.Pipe()

--- a/pkg/ui/interfaces.go
+++ b/pkg/ui/interfaces.go
@@ -18,7 +18,10 @@ import "context"
 
 type UI interface {
 	RenderOutput(ctx context.Context, s string, style ...StyleOption)
-	AskForConfirmation(ctx context.Context, s string) bool
+
+	// AskForConfirmation asks the user for confirmation of a choice.
+	// The user can select one of the validChoices, and the selected choice is returned.
+	AskForConfirmation(ctx context.Context, s string, validChoices []int) (selectedChoice int)
 
 	// ClearScreen clears any output rendered to the screen
 	ClearScreen()


### PR DESCRIPTION
Highlights:

1. `kubectl-ai` will now ask for permission to run `kubectl` commands that modifies resources in user's cluster. Users can override this behavior by using `--skip-permissions` command line flag.
2. Tweaked the confirmation flow to present users will the choice to 1) approve 2) approve and remember the choice for rest of session 3) decline. The option to approve and remember the choice makes the flow less annoying when user is comfortable with the modifying resources and trusts the tool/model more.

The run below shows the confirmation flow:

```sh
$ ./kubectl-ai "double the capacity of nginx application in hello namespace"

  Okay, I can help with that. First, I need to find the deployment for the nginx
  application in the 'hello' namespace and check its current size.

  Running: kubectl get deployment -n hello -o jsonpath="{range .items[?(@.metadata.name==\"nginx\" || contains(@.metadata.name, \"nginx\"))]}{.metadata.name}{'\t'}{.spec.replicas}{'\n'}{end}"

  Okay, I see the previous attempt failed. Let's try finding the specific
  deployment named 'nginx' first and get its current replica count.

  Running: kubectl get deployment nginx -n hello -o jsonpath='{.spec.replicas}'

  Okay, the current deployment 'nginx' in the 'hello' namespace has 1 replica.
  Doubling it means scaling it to 2 replicas.

  Let's scale the deployment now.

  Running: kubectl scale deployment nginx --replicas=2 -n hello
  Do you want to proceed?
  1) Yes
  2) Yes, and don't ask me again
  3) No
  Enter your choice (number): 1

  Done! 🎉 I have scaled the  nginx  deployment in the  hello  namespace to 2
  replicas, effectively doubling its capacity.

```