### PR TITLE
Added Quiet mode

### DIFF
--- a/k8s-bench/eval.go
+++ b/k8s-bench/eval.go
@@ -310,6 +310,7 @@ func (x *TaskExecution) runAgent(ctx context.Context) error {
 		"--kubeconfig", x.kubeConfig,
 		"--llm-provider", x.llmConfig.ProviderID,
 		fmt.Sprintf("--enable-tool-use-shim=%t", x.llmConfig.EnableToolUseShim),
+		fmt.Sprintf("--quiet=%t", x.llmConfig.Quiet),
 		"--model", x.llmConfig.ModelID,
 		"--trace-path", tracePath,
 		"--skip-permissions",

--- a/k8s-bench/main.go
+++ b/k8s-bench/main.go
@@ -155,10 +155,11 @@ func runEvals(ctx context.Context) error {
 		flag.PrintDefaults()
 	}
 
-	llmProvider := "gemini"
+	llmProvider := "gemini://"
 	modelList := ""
 	defaultKubeConfig := "~/.kube/config"
 	enableToolUseShim := true
+	quiet := true
 
 	flag.StringVar(&config.TasksDir, "tasks-dir", config.TasksDir, "Directory containing evaluation tasks")
 	flag.StringVar(&config.KubeConfig, "kubeconfig", config.KubeConfig, "Path to kubeconfig file")
@@ -167,6 +168,7 @@ func runEvals(ctx context.Context) error {
 	flag.StringVar(&llmProvider, "llm-provider", llmProvider, "Specific LLM provider to evaluate (e.g. 'gemini' or 'ollama')")
 	flag.StringVar(&modelList, "models", modelList, "Comma-separated list of models to evaluate (e.g. 'gemini-1.0,gemini-2.0')")
 	flag.BoolVar(&enableToolUseShim, "enable-tool-use-shim", enableToolUseShim, "Enable tool use shim")
+	flag.BoolVar(&quiet, "quiet", quiet, "Quiet mode (non-interactive mode)")
 	flag.StringVar(&config.OutputDir, "output-dir", config.OutputDir, "Directory to write results to")
 	flag.Parse()
 
@@ -181,7 +183,7 @@ func runEvals(ctx context.Context) error {
 	config.KubeConfig = expandedKubeconfig
 
 	defaultModels := map[string][]string{
-		"gemini": {"gemini-2.0-flash-thinking-exp-01-21"},
+		"gemini://": {"gemini-2.5-pro-preview-03-25"},
 	}
 
 	models := defaultModels
@@ -209,6 +211,7 @@ func runEvals(ctx context.Context) error {
 				ProviderID:        llmProviderID,
 				ModelID:           modelID,
 				EnableToolUseShim: enableToolUseShim,
+				Quiet:             quiet,
 			})
 		}
 	}

--- a/k8s-bench/pkg/model/results.go
+++ b/k8s-bench/pkg/model/results.go
@@ -43,6 +43,8 @@ type LLMConfig struct {
 
 	EnableToolUseShim bool `json:"enableToolUseShim"`
 
+	Quiet bool `json:"quiet"`
+
 	// TODO: Maybe different styles of invocation, or different temperatures etc?
 }
 

--- a/pkg/ui/blocks.go
+++ b/pkg/ui/blocks.go
@@ -80,6 +80,10 @@ type FunctionCallRequestBlock struct {
 	text string
 }
 
+func NewFunctionCallRequestBlock() *FunctionCallRequestBlock {
+	return &FunctionCallRequestBlock{}
+}
+
 func (b *FunctionCallRequestBlock) attached(doc *Document) {
 	b.doc = doc
 }


### PR DESCRIPTION
## Highlights

### Quiet mode

This is relevant when you invoke the agent with the query (or task description) on the command line, for ex. `kubectl-ai "bump up the capacity for nginx app"`. This will now drop the user in repl mode by default unless user specified `kubectl-ai --quiet` to disable non-interactive session. This is primarily motivated by my experience of using the tool. I wired the option all the way to `k8s-bench` as well and that helps if you are debugging any eval failure and having access to the repl with all the LLM chat context is useful.

### Bug fixes
 - While using the agent command in a piped syntax or providing the input from stdin, it wasn't compatible with permission and interactive repl flow. Introduced configuration to use tty in those cases.

### Misc

 - Using `gemin-2.5-pro-preview-03-25` by default because it has higher rate limits in free tier by default. Change is in agent as well as k8s-bench.
 - Minor tweak to the approval flow. If user declines running the command, we now record the decline in the chat history and we found LLM handles much more intelligently rest of the flow.
 - We lost the green coloring for function call, so fixed that.


Note: I will update the README as a follow up to include the `quiet` mode.