### PR TITLE
Fix the error building modelserving images

### DIFF
--- a/modelserving/images/llamacpp-server/Dockerfile
+++ b/modelserving/images/llamacpp-server/Dockerfile
@@ -7,7 +7,7 @@ ARG CMAKE_ARGS
 ARG LLAMACPP_TAG
 
 RUN apt-get update
-RUN apt-get install -y g++ git cmake
+RUN apt-get install -y g++ git cmake libcurl4-openssl-dev
 
 WORKDIR /src
 RUN git clone https://github.com/ggml-org/llama.cpp


### PR DESCRIPTION
This fixes this error `CMake could not find CURL` when running `modelserving/dev/tasks/build-images`