### PR TITLE
Allow to specify the LLM provider ID instead of URL

### DIFF
--- a/gollm/factory.go
+++ b/gollm/factory.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"strings"
 	"sync"
 	"time"
 
@@ -58,6 +59,11 @@ func (r *registry) RegisterProvider(id string, factoryFunc FactoryFunc) error {
 }
 
 func (r *registry) NewClient(ctx context.Context, providerID string) (Client, error) {
+	// providerID can be just an ID, for example "gemini" instead of "gemini://"
+	if !strings.Contains(providerID, "/") && !strings.Contains(providerID, ":") {
+		providerID = providerID + "://"
+	}
+
 	u, err := url.Parse(providerID)
 	if err != nil {
 		return nil, fmt.Errorf("parsing provider id %q: %w", providerID, err)


### PR DESCRIPTION
Before:
```sh
> go run . -llm-provider=azopenai -model gpt-4o-mini -quiet "show me all pods in the default namespace"  
creating llm client: provider "" not registered
exit status 1
```
After:
```sh
> go run . -llm-provider=azopenai -model gpt-4o-mini -quiet "show me all pods in the default namespace" 
  Running: kubectl get pods -n default


  Here are all the pods in the default namespace:                                 
                                                                                  
    NAME                                 READY   STATUS    RESTARTS      AGE      
    hello-hello-world-64cfbbf7dc-t7fsf   1/1     Running   1 (79m ago)   4d14h    
                                                                                  
  The pod  hello-hello-world-64cfbbf7dc-t7fsf  is currently running and has been  
  up                                                                              
  for over 4 days. 🚀
```