### PR TITLE
Fixed bug in create-network-policy eval

### DIFF
--- a/k8s-bench/main.go
+++ b/k8s-bench/main.go
@@ -183,7 +183,7 @@ func runEvals(ctx context.Context) error {
 	config.KubeConfig = expandedKubeconfig
 
 	defaultModels := map[string][]string{
-		"gemini://": {"gemini-2.5-pro-preview-03-25"},
+		"gemini": {"gemini-2.5-pro-preview-03-25"},
 	}
 
 	models := defaultModels

--- a/k8s-bench/tasks/create-network-policy/setup.sh
+++ b/k8s-bench/tasks/create-network-policy/setup.sh
@@ -14,13 +14,13 @@ done
 kubectl create namespace ns1
 kubectl create namespace ns2
 
-# Enable NetworkPolicy in both namespaces
-kubectl label namespace ns1 network-policy=enabled --overwrite
-kubectl label namespace ns2 network-policy=enabled --overwrite
-
 # Deploy httpd pods in each namespace for testing connectivity
 kubectl run httpd-ns1 -n ns1 --image=httpd:alpine
 kubectl run httpd-ns2 -n ns2 --image=httpd:alpine
+
+# Expose the httpd pods as services
+kubectl expose pod httpd-ns1 -n ns1 --name=httpd-ns1 --port=80 --target-port=80
+kubectl expose pod httpd-ns2 -n ns2 --name=httpd-ns2 --port=80 --target-port=80
 
 # Deploy test pods with curl for testing connectivity
 kubectl run curl-ns1 -n ns1 --image=curlimages/curl --command -- sleep 3600

--- a/k8s-bench/tasks/create-network-policy/verify.sh
+++ b/k8s-bench/tasks/create-network-policy/verify.sh
@@ -10,7 +10,7 @@ echo "✅ NetworkPolicy 'np' exists in namespace 'ns1'"
 
 # Functional test: Verify ingress traffic is not affected (pod in ns2 can reach pod in ns1)
 echo "Testing that ingress traffic from ns2 to ns1 is not affected..."
-INGRESS_TEST=$(kubectl exec -n ns2 curl-ns2 -- curl -s --connect-timeout 5 http://httpd-ns1.ns1.svc.cluster.local || echo "Failed")
+INGRESS_TEST=$(kubectl exec -n ns2 curl-ns2 -- curl -s --connect-timeout 120s http://httpd-ns1.ns1.svc.cluster.local || echo "Failed")
 if [[ "$INGRESS_TEST" == "Failed" ]]; then
     echo "Failed to connect from ns2 to ns1 - NetworkPolicy should not restrict incoming traffic"
     exit 1
@@ -19,7 +19,7 @@ echo "✅ Ingress traffic from ns2 to ns1 is allowed as expected"
 
 # Functional test: Test connectivity from ns1 to ns2
 echo "Testing connectivity from ns1 to ns2..."
-CURL_RESULT=$(kubectl exec -n ns1 curl-ns1 -- curl -s --connect-timeout 5 http://httpd-ns2.ns2.svc.cluster.local || echo "Failed")
+CURL_RESULT=$(kubectl exec -n ns1 curl-ns1 -- curl -s --connect-timeout 120s http://httpd-ns2.ns2.svc.cluster.local || echo "Failed")
 if [[ "$CURL_RESULT" == "Failed" ]]; then
     echo "Failed to connect from ns1 to ns2 - NetworkPolicy might be too restrictive"
     exit 1
@@ -28,7 +28,7 @@ echo "✅ Pods in ns1 can reach pods in ns2 as expected"
 
 # Functional test: Try to connect to something outside ns2
 echo "Testing that connections outside ns2 are blocked..."
-CURL_RESULT=$(kubectl exec -n ns1 curl-ns1 -- curl -s --connect-timeout 5 https://kubernetes.io || echo "Failed")
+CURL_RESULT=$(kubectl exec -n ns1 curl-ns1 -- curl -s --connect-timeout 10s https://kubernetes.io || echo "Failed")
 if [[ "$CURL_RESULT" != "Failed" ]]; then
     echo "NetworkPolicy should prevent connections to external sites, but connection succeeded"
     exit 1

--- a/main.go
+++ b/main.go
@@ -91,7 +91,7 @@ type Options struct {
 }
 
 func (o *Options) InitDefaults() {
-	o.ProviderID = "gemini://"
+	o.ProviderID = "gemini"
 	o.ModelID = geminiModels[0]
 	// by default, confirm before executing kubectl commands that modify resources in the cluster.
 	o.SkipPermissions = false


### PR DESCRIPTION
Two changes:
 - Found out a bug that was causing this eval to fail for all the models.
 - Revered to llm provider name without the scheme compatible