### PR TITLE
k8s-bench: Fix wrong `indirect` k8s.io/klog/v2 in the go.mod

### DIFF
--- a/k8s-bench/go.mod
+++ b/k8s-bench/go.mod
@@ -8,11 +8,8 @@ replace github.com/GoogleCloudPlatform/kubectl-ai => ./..
 
 require (
 	github.com/GoogleCloudPlatform/kubectl-ai v0.0.0-20250317140348-3b34c8984b9b
+	k8s.io/klog/v2 v2.130.1
 	sigs.k8s.io/yaml v1.4.0
 )
 
-require (
-	github.com/go-logr/logr v1.4.2 // indirect
-	github.com/google/go-cmp v0.6.0 // indirect
-	k8s.io/klog/v2 v2.130.1 // indirect
-)
+require github.com/go-logr/logr v1.4.2 // indirect

--- a/k8s-bench/go.sum
+++ b/k8s-bench/go.sum
@@ -1,5 +1,3 @@
-github.com/GoogleCloudPlatform/kubectl-ai v0.0.0-20250317140348-3b34c8984b9b h1:t1v+aKUlc9echDZFR/tId0xVOWl5l68pvrGNfpRrTm0=
-github.com/GoogleCloudPlatform/kubectl-ai v0.0.0-20250317140348-3b34c8984b9b/go.mod h1:j6t7vxkJfH8kI8Lxbca8pzT20TyzgElh/e3j4q2tXmo=
 github.com/go-logr/logr v1.4.2 h1:6pFjapn8bFcIbiKo3XT4j/BhANplGihG6tvd+8rYgrY=
 github.com/go-logr/logr v1.4.2/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=


### PR DESCRIPTION
The k8s.io/klog/v2 package is not `indirect`. Also cleanup.