### PR TITLE
fix: pass kubeconfig to tool execution

### DIFF
--- a/pkg/agent/conversation.go
+++ b/pkg/agent/conversation.go
@@ -271,7 +271,8 @@ func (a *Conversation) RunOneRound(ctx context.Context, query string) error {
 
 			ctx := journal.ContextWithRecorder(ctx, a.Recorder)
 			output, err := toolCall.InvokeTool(ctx, tools.InvokeToolOptions{
-				WorkDir: a.workDir,
+				Kubeconfig: a.Kubeconfig,
+				WorkDir:    a.workDir,
 			})
 			if err != nil {
 				return fmt.Errorf("executing action: %w", err)


### PR DESCRIPTION
Otherwise the KUBECONFIG variable won't be passed down to the kubectl call
