### PR TITLE
fix: don't dictate the name for the models

### DIFF
--- a/gollm/openai.go
+++ b/gollm/openai.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"net/url"
 	"os"
-	"strings"
 
 	openai "github.com/openai/openai-go"
 	"github.com/openai/openai-go/option"
@@ -80,15 +79,10 @@ func (c *OpenAIClient) Close() error {
 
 // StartChat starts a new chat session.
 func (c *OpenAIClient) StartChat(systemPrompt, model string) Chat {
-	originalModel := model // Keep track of the original for logging
 	// Default to gpt-4o if no model is specified or if it doesn't look like a known OpenAI prefix
-	if model == "" || (!strings.HasPrefix(model, "gpt-") && !strings.HasPrefix(model, "o-")) {
+	if model == "" {
 		model = "gpt-4o"
-		if originalModel == "" {
-			klog.V(1).Info("No model specified, defaulting to gpt-4o")
-		} else {
-			klog.V(1).Infof("Model '%s' does not match expected prefix, defaulting to gpt-4o", originalModel)
-		}
+		klog.V(1).Info("No model specified, defaulting to gpt-4o")
 	}
 	klog.V(1).Infof("Starting new OpenAI chat session with model: %s", model)
 	// Initialize history with system prompt if provided


### PR DESCRIPTION
If the user has chosen a model, it's probably because the user wanted to use it...
