### PR TITLE
fix(tmp): correct overwritten tmp folder mentioned in (#132)

### DIFF
--- a/main.go
+++ b/main.go
@@ -543,7 +543,7 @@ func resolveKubeConfigPath(opt *Options) error {
 }
 
 func startMCPServer(ctx context.Context, opt Options) error {
-	workDir := "/tmp/kubectl-ai-mcp"
+	workDir := filepath.Join(os.TempDir(), "kubectl-ai-mcp")
 	if err := os.MkdirAll(workDir, 0755); err != nil {
 		return fmt.Errorf("error creating work directory: %w", err)
 	}


### PR DESCRIPTION
I noticed that the change of @mattn in this commit https://github.com/GoogleCloudPlatform/kubectl-ai/commit/5fd397b2cf153798f30209fff191258c48289433 did not take effect since there was another change on top of it. I raised this PR to fix it.