### PR TITLE
Omit dollar signs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ First, ensure that kubectl is installed and configured.
 2. Untar the release, make the binary executable and move it to a directory in your $PATH (as shown below).
 
 ```shell
-$ tar -zxvf kubectl-ai_Darwin_arm64.tar.gz
-$ chmod a+x kubectl-ai
-$ sudo mv kubectl-ai /usr/local/bin/
+tar -zxvf kubectl-ai_Darwin_arm64.tar.gz
+chmod a+x kubectl-ai
+sudo mv kubectl-ai /usr/local/bin/
 ```
 
 ### Usage


### PR DESCRIPTION
$ is not part of the command, but a prompt indicator. It is better to avoid including the shell prompt symbol ($) so users can copy commands easily.

Tools like markdownlint support style rules such as [MD014 – Dollar signs used before commands without showing output](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md014), encouraging separation of prompt and command.