### PR TITLE
feat(install): add quick and manual install options in README and script

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ First, ensure that kubectl is installed and configured.
 curl -sSL https://raw.githubusercontent.com/GoogleCloudPlatform/kubectl-ai/main/install.sh | bash
 ```
 
-#### Manual Installation
+#### Manual Installation (Linux, MacOS and Windows)
 
 1. Download the latest release from the [releases page](https://github.com/GoogleCloudPlatform/kubectl-ai/releases/latest) for your target machine.
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,14 @@ First, ensure that kubectl is installed and configured.
 
 ### Installation
 
+#### Quick Install
+
+```shell
+curl -sSL https://raw.githubusercontent.com/GoogleCloudPlatform/kubectl-ai/main/install.sh | bash
+```
+
+#### Manual Installation
+
 1. Download the latest release from the [releases page](https://github.com/GoogleCloudPlatform/kubectl-ai/releases/latest) for your target machine.
 
 2. Untar the release, make the binary executable and move it to a directory in your $PATH (as shown below).

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ First, ensure that kubectl is installed and configured.
 
 ### Installation
 
-#### Quick Install
+#### Quick Install (Linux & MacOS only)
 
 ```shell
 curl -sSL https://raw.githubusercontent.com/GoogleCloudPlatform/kubectl-ai/main/install.sh | bash

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -e
+
+REPO="GoogleCloudPlatform/kubectl-ai"
+BINARY="kubectl-ai"
+
+# Detect OS
+OS="$(uname | tr '[:upper:]' '[:lower:]')"
+case "$OS" in
+  linux)   OS="linux" ;;
+  darwin)  OS="darwin" ;;
+  *) echo "Unsupported OS: $OS"; exit 1 ;;
+esac
+
+# Detect ARCH
+ARCH="$(uname -m)"
+case "$ARCH" in
+  x86_64|amd64) ARCH="amd64" ;;
+  arm64|aarch64) ARCH="arm64" ;;
+  *) echo "Unsupported architecture: $ARCH"; exit 1 ;;
+esac
+
+# Get latest version tag from GitHub API (portable, no grep -P)
+LATEST_TAG=$(curl -s "https://api.github.com/repos/$REPO/releases/latest" | sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p')
+if [ -z "$LATEST_TAG" ]; then
+  echo "Failed to fetch latest release tag."
+  exit 1
+fi
+
+# Compose download URL
+TARBALL="kubectl-ai_${OS}_${ARCH}.tar.gz"
+URL="https://github.com/$REPO/releases/download/$LATEST_TAG/$TARBALL"
+
+# Download and extract
+echo "Downloading $URL ..."
+curl -LO "$URL"
+tar -xzf "$TARBALL"
+
+# Move binary to /usr/local/bin (may require sudo)
+echo "Installing $BINARY to /usr/local/bin (may require sudo)..."
+sudo mv "$BINARY" /usr/local/bin/
+
+# Ensure the binary is executable
+sudo chmod +x /usr/local/bin/$BINARY
+
+# Clean up
+rm "$TARBALL"
+
+echo "✅ $BINARY installed successfully! Run '$BINARY --help' to get started."
+

--- a/install.sh
+++ b/install.sh
@@ -9,7 +9,11 @@ OS="$(uname | tr '[:upper:]' '[:lower:]')"
 case "$OS" in
   linux)   OS="linux" ;;
   darwin)  OS="darwin" ;;
-  *) echo "Unsupported OS: $OS"; exit 1 ;;
+  *)
+    echo "If you are on Windows or another unsupported OS, please follow the manual installation instructions at:"
+    echo "https://github.com/GoogleCloudPlatform/kubectl-ai#manual-installation"
+    exit 1
+    ;;
 esac
 
 # Detect ARCH
@@ -17,7 +21,11 @@ ARCH="$(uname -m)"
 case "$ARCH" in
   x86_64|amd64) ARCH="amd64" ;;
   arm64|aarch64) ARCH="arm64" ;;
-  *) echo "Unsupported architecture: $ARCH"; exit 1 ;;
+  *)
+    echo "If you are on an unsupported architecture, please follow the manual installation instructions at:"
+    echo "https://github.com/GoogleCloudPlatform/kubectl-ai#manual-installation"
+    exit 1
+    ;;
 esac
 
 # Get latest version tag from GitHub API (portable, no grep -P)

--- a/install.sh
+++ b/install.sh
@@ -1,14 +1,22 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Check for required commands
+for cmd in curl tar; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "Error: $cmd is not installed. Please install $cmd to proceed."
+    exit 1
+  fi
+done
+
 REPO="GoogleCloudPlatform/kubectl-ai"
 BINARY="kubectl-ai"
 
 # Detect OS
-OS="$(uname | tr '[:upper:]' '[:lower:]')"
-case "$OS" in
-  linux)   OS="linux" ;;
-  darwin)  OS="darwin" ;;
+sysOS="$(uname | tr '[:upper:]' '[:lower:]')"
+case "$sysOS" in
+  linux)   OS="Linux" ;;
+  darwin)  OS="Darwin" ;;
   *)
     echo "If you are on Windows or another unsupported OS, please follow the manual installation instructions at:"
     echo "https://github.com/GoogleCloudPlatform/kubectl-ai#manual-installation"
@@ -59,4 +67,3 @@ sudo install -m 0755 "$BINARY" /usr/local/bin/
 rm "$TARBALL"
 
 echo "✅ $BINARY installed successfully! Run '$BINARY --help' to get started."
-


### PR DESCRIPTION
## Summary
This update introduces a new `install.sh` script into the repository, enabling streamlined installation of the `kubectl-ai` CLI tool. The script automatically detects the user's OS and architecture, retrieves the latest release from GitHub, and installs the binary into `/usr/local/bin`. This simplifies the setup process, ensuring users can easily deploy the CLI tool with minimal manual steps.

## Affected Modules
- New `install.sh` script added to repository root.

## Key Details
- **OS Detection:** Supports Linux and macOS (Darwin).
- **Architecture Detection:** Supports amd64/x86_64 and arm64/aarch64.
- **Latest Release Fetch:** Uses the GitHub API to automatically identify the most recent release.
- **Installation Method:** Downloads the release tarball, extracts the binary, and installs it to `/usr/local/bin`, with required `sudo` privileges.
- **User Feedback:** Provides clear messaging on download progress, installation status, and success confirmation.

## Potential Impacts
- Provides a quick, reliable method for users to install `kubectl-ai`.
- Facilitates consistency across environments, reducing setup errors.
- Minimal risk; installation relies on standard directory paths and permissions.
