### PR TITLE
Feature: Allow all k8s-bench tasks be executed sequentially

### DIFF
--- a/k8s-bench/README.md
+++ b/k8s-bench/README.md
@@ -10,16 +10,19 @@
 go build
 
 # Run evaluation for scale related tasks
-./k8s-bench run --agent-bin <path/to/kubectl-ai/binary> --task-pattern scale --kubeconfig <path/to/kubeconfig>
+./k8s-bench run --agent-bin <path/to/kubectl-ai/binary> --task-pattern scale --output-dir <output_directory> --kubeconfig <path/to/kubeconfig>
+
+# Run evaluation for all available tasks
+./k8s-bench run --agent-bin <path/to/kubectl-ai/binary> --task-pattern all --output-dir <output_directory> --kubeconfig <path/to/kubeconfig>
 
 # Analyze previous evaluation results and output in markdown format (default)
-./k8s-bench analyze --input-dir .build/k8sbench
+./k8s-bench analyze --input-dir <output_directory>
 
 # Analyze previous evaluation results and output in JSON format
-./k8s-bench analyze --input-dir .build/k8sbench --output-format json
+./k8s-bench analyze --input-dir <output_directory> --output-format json
 
 # Save analysis results to a file
-./k8s-bench analyze --input-dir .build/k8sbench --results-filepath ./results.md
+./k8s-bench analyze --input-dir <output_directory> --results-filepath ./results.md
 ```
 
 Running the benchmark with the `run` subcommand will produce results as below:
@@ -37,4 +40,4 @@ Task: scale-down-deployment
     gemini-2.0-flash-thinking-exp-01-21: true
 ```
 
-The `analyze` subcommand will gather the results from previous runs and display them in a tabular format with emoji indicators for success (✅) and failure (❌). 
+The `analyze` subcommand will gather the results from previous runs and display them in a tabular format with emoji indicators for success (✅) and failure (❌).

--- a/k8s-bench/eval.go
+++ b/k8s-bench/eval.go
@@ -106,8 +106,11 @@ func loadTasks(config EvalConfig) (map[string]Task, error) {
 		}
 
 		taskID := entry.Name()
-		if config.TaskPattern != "" && !strings.Contains(taskID, config.TaskPattern) {
-			continue
+		// Filter tasks by pattern if specified and not "all"
+		if pattern := config.TaskPattern; pattern != "" && pattern != "all" {
+			if !strings.Contains(taskID, pattern) {
+				continue
+			}
 		}
 
 		taskFile := filepath.Join(config.TasksDir, taskID, "task.yaml")


### PR DESCRIPTION
# Motivation

#145 And the previous PR made me think about how could we improve the execution of benchmarks as a whole in `k8s-bench` utility

I created #158 To see what would be the best solution, either keeping it sequential or if we could move into goroutines. as the sequential solution was quite easy to implement, I decided to open this PR.

> Note: It also fixes README examples for k8s-bench, which did not mention the mandatory --output-dir flag

Let me know if you would prefer the goroutine approach or something hyprid, I would like to work on it.

# Testing

```
Evaluation Results:
==================

Task: create-pod
  LLM Config: {ID:shim_disabled-grok-grok-3-beta ProviderID:grok ModelID:grok-3-beta EnableToolUseShim:false Quiet:true}
    success

Task: create-pod-mount-configmaps
  LLM Config: {ID:shim_disabled-grok-grok-3-beta ProviderID:grok ModelID:grok-3-beta EnableToolUseShim:false Quiet:true}
    success

Task: fix-crashloop
  LLM Config: {ID:shim_disabled-grok-grok-3-beta ProviderID:grok ModelID:grok-3-beta EnableToolUseShim:false Quiet:true}
    success

Task: fix-image-pull
  LLM Config: {ID:shim_disabled-grok-grok-3-beta ProviderID:grok ModelID:grok-3-beta EnableToolUseShim:false Quiet:true}
    success

Task: fix-service-routing
  LLM Config: {ID:shim_disabled-grok-grok-3-beta ProviderID:grok ModelID:grok-3-beta EnableToolUseShim:false Quiet:true}
    success

Task: scale-deployment
  LLM Config: {ID:shim_disabled-grok-grok-3-beta ProviderID:grok ModelID:grok-3-beta EnableToolUseShim:false Quiet:true}
    success

Task: scale-down-deployment
  LLM Config: {ID:shim_disabled-grok-grok-3-beta ProviderID:grok ModelID:grok-3-beta EnableToolUseShim:false Quiet:true}
    success

Task: create-network-policy
  LLM Config: {ID:shim_disabled-grok-grok-3-beta ProviderID:grok ModelID:grok-3-beta EnableToolUseShim:false Quiet:true}
    
    Error: running command /home/zvdy/Desktop/kubectl-ai/k8s-bench/tasks/create-network-policy/verify.sh: exit status 1

Task: create-pod-resources-limits
  LLM Config: {ID:shim_disabled-grok-grok-3-beta ProviderID:grok ModelID:grok-3-beta EnableToolUseShim:false Quiet:true}
    success

Task: list-images-for-pods
  LLM Config: {ID:shim_disabled-grok-grok-3-beta ProviderID:grok ModelID:grok-3-beta EnableToolUseShim:false Quiet:true}
    success
```     
### time
`10,90s user 2,31s system 1% cpu 11:08,00 total` 
_~I know this depends on hardware but works as a estimate_
