### PR TITLE
k8s-bench | health probe troubleshooting eval task #145

### DIFF
--- a/k8s-bench/tasks/fix-probes/cleanup.sh
+++ b/k8s-bench/tasks/fix-probes/cleanup.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# Delete the namespace which will remove all resources created for this task
+kubectl delete namespace health-check --ignore-not-found
+
+echo "Cleanup completed"

--- a/k8s-bench/tasks/fix-probes/setup.sh
+++ b/k8s-bench/tasks/fix-probes/setup.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+# Delete namespace if exists and create a fresh one
+kubectl delete namespace health-check --ignore-not-found
+kubectl create namespace health-check
+
+# Create a deployment with problematic health checks
+cat <<YAML | kubectl apply -f -
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: webapp
+  namespace: health-check
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: webapp
+  template:
+    metadata:
+      labels:
+        app: webapp
+    spec:
+      containers:
+      - name: webapp
+        image: nginx:latest
+        ports:
+        - containerPort: 80
+        # The problem: incorrect health probes causing restarts
+        livenessProbe:
+          httpGet:
+            path: /nonexistent-path  # Path doesn't exist
+            port: 80
+          initialDelaySeconds: 5
+          periodSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /nonexistent-path  # Path doesn't exist
+            port: 80
+          initialDelaySeconds: 5
+          periodSeconds: 5
+YAML
+
+# Create a service for the webapp
+kubectl create service clusterip webapp -n health-check --tcp=80:80
+
+# Wait for the pod to start and begin restarting due to failed probes
+echo "Waiting for pod to start and begin failing health checks..."
+sleep 10
+
+# Show the pod status to confirm it's having health check issues
+kubectl get pods -n health-check

--- a/k8s-bench/tasks/fix-probes/task.yaml
+++ b/k8s-bench/tasks/fix-probes/task.yaml
@@ -1,0 +1,6 @@
+script:
+- prompt: "Please fix the health check issue with the deployment named 'webapp' in namespace 'health-check'"
+setup: "setup.sh"
+verifier: "verify.sh"
+cleanup: "cleanup.sh"
+difficulty: "medium"

--- a/k8s-bench/tasks/fix-probes/verify.sh
+++ b/k8s-bench/tasks/fix-probes/verify.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# Check if the pod is in Running state with Ready status
+echo "Checking if the pod is running and ready..."
+
+# Wait up to 30 seconds for pod to become ready
+for i in {1..15}; do
+  READY=$(kubectl get pods -n health-check -l app=webapp -o jsonpath='{.items[0].status.containerStatuses[0].ready}')
+  if [ "$READY" == "true" ]; then
+    echo "Success: Pod is now Ready"
+    
+    # Get the current probe configuration
+    PROBE_PATH=$(kubectl get deploy webapp -n health-check -o jsonpath='{.spec.template.spec.containers[0].livenessProbe.httpGet.path}')
+    
+    echo "Current probe path: $PROBE_PATH"
+    
+    # Verify the probe is not using the nonexistent path
+    if [ "$PROBE_PATH" != "/nonexistent-path" ]; then
+      echo "Success: Probe path has been fixed"
+      
+      # Check if pod is stable with no recent restarts
+      RESTARTS=$(kubectl get pods -n health-check -l app=webapp -o jsonpath='{.items[0].status.containerStatuses[0].restartCount}')
+      if [ "$RESTARTS" -lt 5 ]; then
+        echo "Success: Pod is stable with acceptable number of restarts"
+        exit 0
+      else
+        echo "Failure: Pod has too many restarts: $RESTARTS"
+        exit 1
+      fi
+    else
+      echo "Failure: Probe path is still incorrect"
+      exit 1
+    fi
+  fi
+  sleep 2
+done
+
+echo "Failure: Pod is not Ready after waiting"
+kubectl get pods -n health-check -l app=webapp
+exit 1


### PR DESCRIPTION
# Eval task

Deploys a simple `webapp` pod pointing to a nonexistent path, causing health-check failure 

```yaml
        livenessProbe:
          httpGet:
            path: /nonexistent-path  # Path doesn't exist
            port: 80
          initialDelaySeconds: 5
          periodSeconds: 5
        readinessProbe:
          httpGet:
            path: /nonexistent-path  # Path doesn't exist
            port: 80
          initialDelaySeconds: 5
          periodSeconds: 5
```

Expects the LLM to point to a correct path so the pod passes its health check 

## Tests

```
Evaluation Results:
==================

Task: fix-probes
  LLM Config: {ID:shim_disabled-grok-grok-3-beta ProviderID:grok ModelID:grok-3-beta EnableToolUseShim:false Quiet:true}
    success
```