### PR TITLE
refactor(tools): use typed context keys for kubeconfig and work_dir

### DIFF
--- a/mcp.go
+++ b/mcp.go
@@ -17,7 +17,6 @@ package main
 import (
 	"context"
 	"fmt"
-	
 	"github.com/GoogleCloudPlatform/kubectl-ai/pkg/tools"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
@@ -71,7 +70,7 @@ func (s *kubectlMCPServer) handleToolCall(ctx context.Context, request mcp.CallT
 
 	ctx = context.WithValue(ctx, tools.KubeconfigKey, s.kubectlConfig)
 	ctx = context.WithValue(ctx, tools.WorkDirKey, s.workDir)
-	
+
 	tool := tools.Lookup(name)
 	if tool == nil {
 		return &mcp.CallToolResult{

--- a/mcp.go
+++ b/mcp.go
@@ -17,7 +17,7 @@ package main
 import (
 	"context"
 	"fmt"
-
+	
 	"github.com/GoogleCloudPlatform/kubectl-ai/pkg/tools"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
@@ -69,9 +69,9 @@ func (s *kubectlMCPServer) handleToolCall(ctx context.Context, request mcp.CallT
 	modifiesResource := request.Params.Arguments["modifies_resource"].(string)
 	log.Info("Received tool call", "tool", name, "command", command, "modifies_resource", modifiesResource)
 
-	ctx = context.WithValue(ctx, "kubeconfig", s.kubectlConfig)
-	ctx = context.WithValue(ctx, "work_dir", s.workDir)
-
+	ctx = context.WithValue(ctx, tools.KubeconfigKey, s.kubectlConfig)
+	ctx = context.WithValue(ctx, tools.WorkDirKey, s.workDir)
+	
 	tool := tools.Lookup(name)
 	if tool == nil {
 		return &mcp.CallToolResult{

--- a/pkg/tools/bash_tool.go
+++ b/pkg/tools/bash_tool.go
@@ -84,8 +84,8 @@ Possible values:
 }
 
 func (t *BashTool) Run(ctx context.Context, args map[string]any) (any, error) {
-	kubeconfig := ctx.Value("kubeconfig").(string)
-	workDir := ctx.Value("work_dir").(string)
+	kubeconfig := ctx.Value(KubeconfigKey).(string)
+	workDir := ctx.Value(WorkDirKey).(string)
 	command := args["command"].(string)
 
 	if strings.Contains(command, "kubectl edit") {

--- a/pkg/tools/kubectl_tool.go
+++ b/pkg/tools/kubectl_tool.go
@@ -71,8 +71,8 @@ Possible values:
 }
 
 func (t *Kubectl) Run(ctx context.Context, args map[string]any) (any, error) {
-	kubeconfig := ctx.Value("kubeconfig").(string)
-	workDir := ctx.Value("work_dir").(string)
+	kubeconfig := ctx.Value(KubeconfigKey).(string)
+	workDir := ctx.Value(WorkDirKey).(string)
 	command := args["command"].(string)
 
 	return runKubectlCommand(ctx, command, workDir, kubeconfig)

--- a/pkg/tools/tools.go
+++ b/pkg/tools/tools.go
@@ -28,11 +28,11 @@ import (
 	"github.com/google/uuid"
 )
 
-type contextKey string
+type ContextKey string
 
 const (
-	kubeconfigKey contextKey = "kubeconfig"
-	workDirKey    contextKey = "work_dir"
+	KubeconfigKey ContextKey = "kubeconfig"
+	WorkDirKey    ContextKey = "work_dir"
 )
 
 func Lookup(name string) Tool {
@@ -144,8 +144,8 @@ func (t *ToolCall) InvokeTool(ctx context.Context, opt InvokeToolOptions) (any, 
 		},
 	})
 
-	ctx = context.WithValue(ctx, kubeconfigKey, opt.Kubeconfig)
-	ctx = context.WithValue(ctx, workDirKey, opt.WorkDir)
+	ctx = context.WithValue(ctx, KubeconfigKey, opt.Kubeconfig)
+	ctx = context.WithValue(ctx, WorkDirKey, opt.WorkDir)
 
 	response, err := t.tool.Run(ctx, t.arguments)
 

--- a/pkg/tools/tools.go
+++ b/pkg/tools/tools.go
@@ -28,6 +28,13 @@ import (
 	"github.com/google/uuid"
 )
 
+type contextKey string
+
+const (
+	kubeconfigKey contextKey = "kubeconfig"
+	workDirKey    contextKey = "work_dir"
+)
+
 func Lookup(name string) Tool {
 	return allTools.Lookup(name)
 }
@@ -137,8 +144,8 @@ func (t *ToolCall) InvokeTool(ctx context.Context, opt InvokeToolOptions) (any, 
 		},
 	})
 
-	ctx = context.WithValue(ctx, "kubeconfig", opt.Kubeconfig)
-	ctx = context.WithValue(ctx, "work_dir", opt.WorkDir)
+	ctx = context.WithValue(ctx, kubeconfigKey, opt.Kubeconfig)
+	ctx = context.WithValue(ctx, workDirKey, opt.WorkDir)
 
 	response, err := t.tool.Run(ctx, t.arguments)
 

--- a/pkg/tools/trivy_tool.go
+++ b/pkg/tools/trivy_tool.go
@@ -59,7 +59,7 @@ func (t *ScanImageWithTrivy) FunctionDefinition() *gollm.FunctionDefinition {
 }
 
 func (t *ScanImageWithTrivy) Run(ctx context.Context, functionArgs map[string]any) (any, error) {
-	workDir := ctx.Value("work_dir").(string)
+	workDir := ctx.Value(WorkDirKey).(string)
 
 	if err := parseFunctionArgs(functionArgs, t); err != nil {
 		return nil, err


### PR DESCRIPTION
- Replaced string keys with a custom contextKey type for kubeconfig and work_dir
- Prevents context key collisions and follows Go best practices
- Resolves static analysis/linter warnings
- No functional changes

Closes #174