### PR TITLE
fix Observable#AddSubscription on s is shadowed

### DIFF
--- a/pkg/ui/observable.go
+++ b/pkg/ui/observable.go
@@ -49,12 +49,8 @@ func (o *Observable[T]) AddSubscription(subscriber ObservableSubscriber[T]) io.C
 		subscriber: subscriber,
 	}
 
-	for i, s := range o.subscriptions {
-		if s == nil {
-			o.subscriptions[i] = s
-			return s
-		}
-		if s.subscriber == nil {
+	for i, e := range o.subscriptions {
+		if e == nil || e.subscriber == nil {
 			o.subscriptions[i] = s
 			return s
 		}


### PR DESCRIPTION
The variable s is defined again inside the for-loop, which causes the external variable s to be hidden, which in turn causes the for-loop to be handled incorrectly.