### PR TITLE
Chore: add existence check for build-images script

### DIFF
--- a/modelserving/dev/tasks/run-local
+++ b/modelserving/dev/tasks/run-local
@@ -12,6 +12,11 @@ cd "${SRC_DIR}"
 export ARCHITECTURES=cpu # TODO: we could support cuda locally, but it is slow to build..
 
 # Build and export the docker image; so we are consistent in how we build
+[[ -x dev/tasks/build-images ]] || {
+  echo "ERROR: build-images script not found or not executable"
+  exit 1
+}
+
 mkdir -p .build/llamacpp-server-cpu
 BUILDX_ARGS="--output type=local,dest=.build/llamacpp-server-cpu" dev/tasks/build-images
 


### PR DESCRIPTION
### Summary

This PR improves the robustness of the `run-local` script used for building and launching the local `llama-server`. It adds a safety check to ensure that the required `dev/tasks/build-images` script exists and is executable before attempting to run it.

### Change Details

- ✅ Added an existence and executability check:
  ```bash
  [[ -x dev/tasks/build-images ]] || {
    echo "build-images not found"; exit 1;
  }
  ```
  
 •	Prevents obscure failures in environments where the build script may be missing or not yet generated.
•	Makes the development workflow more predictable and user-friendly.

❓Why

Without this check, the script would fail with a less descriptive error if build-images is missing or lacks execution permission. This change provides an early and clear error message, improving developer experience.

No functional behavior of the build itself is changed.

