### PR TITLE
Doc enhancement: Add OLLAMA_HOST into example

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ An example of using Google's `gemma3` model with `ollama`:
 # assuming ollama is already running and you have pulled one of the gemma models
 # ollama pull gemma3:12b-it-qat
 
+# if your ollama server is at remote, use OLLAMA_HOST variable to specify the host
+# export OLLAMA_HOST=http://192.168.1.3:11434/
+
 # enable-tool-use-shim because models require special prompting to enable tool calling
 kubectl-ai --llm-provider ollama --model gemma3:12b-it-qat --enable-tool-use-shim
 


### PR DESCRIPTION
I'm trying to use remote ollama server as llm-provider. But there is no example to do that.

After few hours tracing the code, I found the answer: 
https://github.com/ollama/ollama/blob/0d6e35d3c67cf37de1c425d178c71d7351083013/envconfig/config.go#L17

### Details

[`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R58-R60): Added a note on how to use the `OLLAMA_HOST` variable to specify the host of a remote `ollama` server. the documentation, add OLLAMA_HOST into example.