### PR TITLE
refactor: simplify AgentTextBlock methods and improve message handling

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -427,7 +427,7 @@ type session struct {
 func (s *session) repl(ctx context.Context, initialQuery string) error {
 	query := initialQuery
 	if query == "" {
-		s.doc.AddBlock(ui.NewAgentTextBlock().SetText("Hey there, what can I help you with today?"))
+		s.doc.AddBlock(ui.NewAgentTextBlock().WithText("Hey there, what can I help you with today?"))
 	}
 	for {
 		if query == "" {

--- a/pkg/agent/conversation.go
+++ b/pkg/agent/conversation.go
@@ -256,7 +256,7 @@ func (a *Conversation) RunOneRound(ctx context.Context, query string) error {
 				case "2":
 					a.SkipPermissions = true
 				case "3":
-					a.doc.AddBlock(ui.NewAgentTextBlock().SetText("Operation was skipped."))
+					a.doc.AddBlock(ui.NewAgentTextBlock().WithText("Operation was skipped."))
 					observation := fmt.Sprintf("User didn't approve running %q.\n", call.Name)
 					currChatContent = append(currChatContent, observation)
 					continue

--- a/pkg/ui/blocks.go
+++ b/pkg/ui/blocks.go
@@ -48,28 +48,29 @@ func (b *AgentTextBlock) Streaming() bool {
 	return b.streaming
 }
 
-func (b *AgentTextBlock) SetStreaming(streaming bool) *AgentTextBlock {
+func (b *AgentTextBlock) SetStreaming(streaming bool) {
 	b.streaming = streaming
 	b.doc.blockChanged(b)
-	return b
 }
 
-func (b *AgentTextBlock) SetColor(color ColorValue) *AgentTextBlock {
+func (b *AgentTextBlock) SetColor(color ColorValue) {
 	b.Color = color
 	b.doc.blockChanged(b)
-	return b
 }
 
-func (b *AgentTextBlock) SetText(agentText string) *AgentTextBlock {
+func (b *AgentTextBlock) SetText(agentText string) {
 	b.text = agentText
 	b.doc.blockChanged(b)
+}
+
+func (b *AgentTextBlock) WithText(agentText string) *AgentTextBlock {
+	b.SetText(agentText)
 	return b
 }
 
-func (b *AgentTextBlock) AppendText(text string) *AgentTextBlock {
+func (b *AgentTextBlock) AppendText(text string) {
 	b.text = b.text + text
 	b.doc.blockChanged(b)
-	return b
 }
 
 // FunctionCallRequestBlock is used to render the LLM's request to invoke a function


### PR DESCRIPTION
Returning the object pointer from a set accessor might not be the most expected method signature. 