### PR TITLE
k8s-bench concurrent task execution

### DIFF
--- a/k8s-bench/README.md
+++ b/k8s-bench/README.md
@@ -24,6 +24,9 @@ The `run` subcommand executes the benchmark evaluations.
 # Run evaluation for a specific LLM provider and model with tool use shim disabled
 ./k8s-bench run --llm-provider=grok --models=grok-3-beta --agent-bin ../kubectl-ai --task-pattern=fix-probes --enable-tool-use-shim=false --output-dir .build/k8sbench
 
+# Run evaluation sequentially (one task at a time)
+./k8s-bench run --agent-bin <path/to/kubectl-ai/binary> --tasks-dir ./tasks --output-dir .build/k8sbench --concurrency 1
+
 # Run evaluation with all available options
 ./k8s-bench run \
   --agent-bin <path/to/kubectl-ai/binary> \
@@ -34,6 +37,7 @@ The `run` subcommand executes the benchmark evaluations.
   --models gemini-2.5-pro-preview-03-25,gemini-1.5-pro-latest \
   --enable-tool-use-shim true \
   --quiet true \
+  --concurrency 0 \
   --output-dir .build/k8sbench
 ```
 
@@ -50,6 +54,7 @@ The `run` subcommand executes the benchmark evaluations.
 | `--models` | Comma-separated list of models to evaluate | gemini-2.5-pro-preview-03-25 | No |
 | `--enable-tool-use-shim` | Enable tool use shim | true | No |
 | `--quiet` | Quiet mode (non-interactive mode) | true | No |
+| `--concurrency` | Number of tasks to run concurrently (0 = auto based on number of tasks, 1 = sequential, N = run N tasks at a time) | 0 | No |
 
 #### Analyze Subcommand
 


### PR DESCRIPTION
# Motivation

As mentioned in #158, instead of executing tasks sequentially (where total time equals the sum of all task durations) as current implementation does, tasks now run in parallel using `goroutines` (where total time approaches the longest individual task plus minimal overhead).

## Features

- Add `--concurrency` flag to control parallelism:
  - 0 (default): Auto-configure to match the number of tasks
  - 1: Run sequentially (original behavior)
  - N: Run N tasks concurrently

- Dynamic adjustment based on available tasks
- Proper error handling and result collection from all workers
- Updated documentation in README.md

## Technical Implementation

The implementation uses Go's concurrency primitives:

1. **Worker Pool Pattern**:
   - Created a bounded worker pool with configurable size based on the concurrency flag
   - Each worker runs in its own goroutine and processes tasks from a shared channel

2. **Channel Coordination**:
   - `taskCh`: Distributes tasks to worker goroutines
   - `resultsCh`: Collects evaluation results from all workers
   - `errorsCh`: Captures errors that might occur during execution

3. **Synchronization**:
   - `sync.WaitGroup` ensures all workers complete before aggregating results
   - Channel capacity is pre-allocated based on the number of tasks to prevent blocking

4. **Resource Management**:
   - Each worker handles its own file I/O for logs and result files
   - Output directory structure remains consistent with the sequential implementation

This implementation maintains the existing functionality while providing significant performance improvements for multi-task benchmarks. Which can also be implemented into a testing suite or CI/CD pipeline with github actions #196 

## Testing 

### Setup all concurrent tasks:
![image](https://github.com/user-attachments/assets/32956f03-eda2-4b36-8290-3ecae553dab7)

### Simultaneous namespace creation 
> _(this needs to be taken into consideration so no tasks use same namespace names, although it makes sense to do it like that anyways)_
![image](https://github.com/user-attachments/assets/7aa385e8-bd17-4ea3-b2e8-77f8900a5ad9)
