### PR TITLE
Add support for additional prompt template files

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -82,14 +82,14 @@ type Options struct {
 	EnableToolUseShim bool `json:"enableToolUseShim,omitempty"`
 	// Quiet flag indicates if the agent should run in non-interactive mode.
 	// It requires a query to be provided as a positional argument.
-	Quiet                             bool     `json:"quiet,omitempty"`
-	MCPServer                         bool     `json:"mcpServer,omitempty"`
-	MaxIterations                     int      `json:"maxIterations,omitempty"`
-	KubeConfigPath                    string   `json:"kubeConfigPath,omitempty"`
-	PromptTemplateFilePath            string   `json:"promptTemplateFilePath,omitempty"`
-	AdditionalPromptTemplateFilePaths []string `json:"additionalPromptTemplateFilePaths,omitempty"`
-	TracePath                         string   `json:"tracePath,omitempty"`
-	RemoveWorkDir                     bool     `json:"removeWorkDir,omitempty"`
+	Quiet                  bool     `json:"quiet,omitempty"`
+	MCPServer              bool     `json:"mcpServer,omitempty"`
+	MaxIterations          int      `json:"maxIterations,omitempty"`
+	KubeConfigPath         string   `json:"kubeConfigPath,omitempty"`
+	PromptTemplateFilePath string   `json:"promptTemplateFilePath,omitempty"`
+	ExtraPromptPaths       []string `json:"extraPromptPaths,omitempty"`
+	TracePath              string   `json:"tracePath,omitempty"`
+	RemoveWorkDir          bool     `json:"removeWorkDir,omitempty"`
 
 	// UserInterface is the type of user interface to use.
 	UserInterface UserInterface `json:"userInterface,omitempty"`
@@ -135,7 +135,7 @@ func (o *Options) InitDefaults() {
 	o.MaxIterations = 20
 	o.KubeConfigPath = ""
 	o.PromptTemplateFilePath = ""
-	o.AdditionalPromptTemplateFilePaths = []string{}
+	o.ExtraPromptPaths = []string{}
 	o.TracePath = filepath.Join(os.TempDir(), "kubectl-ai-trace.txt")
 	o.RemoveWorkDir = false
 
@@ -259,7 +259,7 @@ func (opt *Options) bindCLIFlagsToViper(f *pflag.FlagSet) error {
 	f.IntVar(&opt.MaxIterations, "max-iterations", opt.MaxIterations, "maximum number of iterations agent will try before giving up")
 	f.StringVar(&opt.KubeConfigPath, "kubeconfig", opt.KubeConfigPath, "path to kubeconfig file")
 	f.StringVar(&opt.PromptTemplateFilePath, "prompt-template-file-path", opt.PromptTemplateFilePath, "path to custom prompt template file")
-	f.StringArrayVar(&opt.AdditionalPromptTemplateFilePaths, "additional-prompt-template-file-paths", opt.AdditionalPromptTemplateFilePaths, "additional paths to custom prompt template files")
+	f.StringArrayVar(&opt.ExtraPromptPaths, "extra-prompt-paths", opt.ExtraPromptPaths, "extra prompt template paths")
 	f.StringVar(&opt.TracePath, "trace-path", opt.TracePath, "path to the trace file")
 	f.BoolVar(&opt.RemoveWorkDir, "remove-workdir", opt.RemoveWorkDir, "remove the temporary working directory after execution")
 
@@ -380,17 +380,17 @@ func RunRootCommand(ctx context.Context, opt Options, args []string) error {
 	}
 
 	conversation := &agent.Conversation{
-		Model:                     opt.ModelID,
-		Kubeconfig:                opt.KubeConfigPath,
-		LLM:                       llmClient,
-		MaxIterations:             opt.MaxIterations,
-		PromptTemplateFile:        opt.PromptTemplateFilePath,
-		AdditionalPromptTemplates: opt.AdditionalPromptTemplateFilePaths,
-		Tools:                     tools.Default(),
-		Recorder:                  recorder,
-		RemoveWorkDir:             opt.RemoveWorkDir,
-		SkipPermissions:           opt.SkipPermissions,
-		EnableToolUseShim:         opt.EnableToolUseShim,
+		Model:              opt.ModelID,
+		Kubeconfig:         opt.KubeConfigPath,
+		LLM:                llmClient,
+		MaxIterations:      opt.MaxIterations,
+		PromptTemplateFile: opt.PromptTemplateFilePath,
+		ExtraPromptPaths:   opt.ExtraPromptPaths,
+		Tools:              tools.Default(),
+		Recorder:           recorder,
+		RemoveWorkDir:      opt.RemoveWorkDir,
+		SkipPermissions:    opt.SkipPermissions,
+		EnableToolUseShim:  opt.EnableToolUseShim,
 	}
 
 	err = conversation.Init(ctx, doc)

--- a/pkg/agent/conversation.go
+++ b/pkg/agent/conversation.go
@@ -41,10 +41,10 @@ type Conversation struct {
 
 	// PromptTemplateFile allows specifying a custom template file
 	PromptTemplateFile string
-	// AdditionalPromptTemplates allows specifying additional prompt templates
+	// ExtraPromptPaths allows specifying additional prompt templates
 	// to be combined with PromptTemplateFile
-	AdditionalPromptTemplates []string
-	Model                     string
+	ExtraPromptPaths []string
+	Model            string
 
 	RemoveWorkDir bool
 
@@ -339,10 +339,10 @@ func (a *Conversation) generatePrompt(_ context.Context, defaultPromptTemplate s
 		promptTemplate = string(content)
 	}
 
-	for _, additionalPromptTemplate := range a.AdditionalPromptTemplates {
-		content, err := os.ReadFile(additionalPromptTemplate)
+	for _, extraPromptPath := range a.ExtraPromptPaths {
+		content, err := os.ReadFile(extraPromptPath)
 		if err != nil {
-			return "", fmt.Errorf("error reading additional template file: %v", err)
+			return "", fmt.Errorf("error reading extra prompt path: %v", err)
 		}
 		promptTemplate += "\n" + string(content)
 	}

--- a/pkg/agent/conversation.go
+++ b/pkg/agent/conversation.go
@@ -41,7 +41,10 @@ type Conversation struct {
 
 	// PromptTemplateFile allows specifying a custom template file
 	PromptTemplateFile string
-	Model              string
+	// AdditionalPromptTemplates allows specifying additional prompt templates
+	// to be combined with PromptTemplateFile
+	AdditionalPromptTemplates []string
+	Model                     string
 
 	RemoveWorkDir bool
 
@@ -334,6 +337,14 @@ func (a *Conversation) generatePrompt(_ context.Context, defaultPromptTemplate s
 			return "", fmt.Errorf("error reading template file: %v", err)
 		}
 		promptTemplate = string(content)
+	}
+
+	for _, additionalPromptTemplate := range a.AdditionalPromptTemplates {
+		content, err := os.ReadFile(additionalPromptTemplate)
+		if err != nil {
+			return "", fmt.Errorf("error reading additional template file: %v", err)
+		}
+		promptTemplate += "\n" + string(content)
 	}
 
 	tmpl, err := template.New("promptTemplate").Parse(promptTemplate)


### PR DESCRIPTION
Close #204 

Add `--additional-prompt-template-file-paths` flag with templates that are appended to the default prompt file when generating the prompt.