### PR TITLE
feat: add configurable SSL verification and refactor client options

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -92,6 +92,9 @@ type Options struct {
 
 	// UserInterface is the type of user interface to use.
 	UserInterface UserInterface `json:"userInterface,omitempty"`
+
+	// SkipVerifySSL is a flag to skip verifying the SSL certificate of the LLM provider.
+	SkipVerifySSL bool `json:"skipVerifySSL,omitempty"`
 }
 
 type UserInterface string
@@ -139,6 +142,9 @@ func (o *Options) InitDefaults() {
 
 	// Default to terminal UI
 	o.UserInterface = UserInterfaceTerminal
+
+	// Default to not skipping SSL verification
+	o.SkipVerifySSL = false
 }
 
 func (o *Options) LoadConfiguration(b []byte) error {
@@ -268,6 +274,7 @@ func (opt *Options) bindCLIFlagsToViper(f *pflag.FlagSet) error {
 	f.BoolVar(&opt.Quiet, "quiet", opt.Quiet, "run in non-interactive mode, requires a query to be provided as a positional argument")
 
 	f.Var(&opt.UserInterface, "user-interface", "user interface mode to use")
+	f.BoolVar(&opt.SkipVerifySSL, "skip-verify-ssl", opt.SkipVerifySSL, "skip verifying the SSL certificate of the LLM provider")
 
 	// viper binds and env var prefixes
 	if err := loadViperFlags(f); err != nil {
@@ -301,32 +308,41 @@ func setupViperEnv() {
 }
 
 func RunRootCommand(ctx context.Context, opt Options, args []string) error {
+	var err error // Declare err once for the whole function
+
 	// resolve kubeconfig path with priority: flag/env > KUBECONFIG > default path
-	if err := resolveKubeConfigPath(&opt); err != nil {
+	if err = resolveKubeConfigPath(&opt); err != nil {
 		return fmt.Errorf("failed to resolve kubeconfig path: %w", err)
 	}
 
 	if opt.MCPServer {
-		if err := startMCPServer(ctx, opt); err != nil {
+		if err = startMCPServer(ctx, opt); err != nil {
 			return fmt.Errorf("failed to start MCP server: %w", err)
 		}
 	}
 
 	// After reading stdin, it is consumed
-	hasStdInData, err := hasStdInData()
+	var hasInputData bool
+	hasInputData, err = hasStdInData()
 	if err != nil {
 		return fmt.Errorf("failed to check if stdin has data: %w", err)
 	}
 
 	// Handles positional args or stdin
-	queryFromCmd, err := resolveQueryInput(hasStdInData, args)
+	var queryFromCmd string
+	queryFromCmd, err = resolveQueryInput(hasInputData, args)
 	if err != nil {
 		return fmt.Errorf("failed to resolve query input %w", err)
 	}
 
 	klog.Info("Application started", "pid", os.Getpid())
 
-	llmClient, err := gollm.NewClient(ctx, opt.ProviderID)
+	var llmClient gollm.Client
+	if opt.SkipVerifySSL {
+		llmClient, err = gollm.NewClient(ctx, opt.ProviderID, gollm.WithSkipVerifySSL())
+	} else {
+		llmClient, err = gollm.NewClient(ctx, opt.ProviderID)
+	}
 	if err != nil {
 		return fmt.Errorf("creating llm client: %w", err)
 	}
@@ -334,7 +350,8 @@ func RunRootCommand(ctx context.Context, opt Options, args []string) error {
 
 	var recorder journal.Recorder
 	if opt.TracePath != "" {
-		fileRecorder, err := journal.NewFileRecorder(opt.TracePath)
+		var fileRecorder journal.Recorder
+		fileRecorder, err = journal.NewFileRecorder(opt.TracePath)
 		if err != nil {
 			return fmt.Errorf("creating trace recorder: %w", err)
 		}
@@ -352,24 +369,29 @@ func RunRootCommand(ctx context.Context, opt Options, args []string) error {
 	switch opt.UserInterface {
 	case UserInterfaceTerminal:
 		// since stdin is already consumed, we use TTY for taking input from user
-		useTTYForInput := hasStdInData
+		useTTYForInput := hasInputData
 
-		u, err := ui.NewTerminalUI(doc, recorder, useTTYForInput)
+		var u ui.UI
+		u, err = ui.NewTerminalUI(doc, recorder, useTTYForInput)
 		if err != nil {
 			return err
 		}
 		userInterface = u
 
 	case UserInterfaceHTML:
-		u, err := html.NewHTMLUserInterface(doc, recorder)
+		var u ui.UI
+		u, err = html.NewHTMLUserInterface(doc, recorder)
 		if err != nil {
 			return err
 		}
-		go func() {
-			if err := u.RunServer(ctx); err != nil {
-				klog.Fatalf("error running http server: %v", err)
-			}
-		}()
+		// Only run server if the UI is actually an HTML UI
+		if htmlUI, ok := u.(*html.HTMLUserInterface); ok {
+			go func() {
+				if err := htmlUI.RunServer(ctx); err != nil {
+					klog.Fatalf("error running http server: %v", err)
+				}
+			}()
+		}
 		userInterface = u
 
 	default:
@@ -613,7 +635,7 @@ func resolveKubeConfigPath(opt *Options) error {
 
 func startMCPServer(ctx context.Context, opt Options) error {
 	workDir := filepath.Join(os.TempDir(), "kubectl-ai-mcp")
-	if err := os.MkdirAll(workDir, 0755); err != nil {
+	if err := os.MkdirAll(workDir, 0o755); err != nil {
 		return fmt.Errorf("error creating work directory: %w", err)
 	}
 	mcpServer, err := newKubectlMCPServer(ctx, opt.KubeConfigPath, tools.Default(), workDir)

--- a/gollm/gemini.go
+++ b/gollm/gemini.go
@@ -23,7 +23,6 @@ import (
 	"iter"
 	"net"
 	"net/http"
-	"net/url"
 	"os"
 	"os/exec"
 	"strings"
@@ -42,9 +41,10 @@ func init() {
 	}
 }
 
-func geminiFactory(ctx context.Context, u *url.URL) (Client, error) {
+// geminiFactory is the provider factory function for Gemini.
+// Supports ClientOptions for consistency, but skipVerifySSL is not used.
+func geminiFactory(ctx context.Context, opts ClientOptions) (Client, error) {
 	opt := GeminiAPIClientOptions{}
-
 	return NewGeminiAPIClient(ctx, opt)
 }
 
@@ -86,9 +86,10 @@ type VertexAIClientOptions struct {
 	Location string
 }
 
-func vertexaiViaGeminiFactory(ctx context.Context, u *url.URL) (Client, error) {
+// vertexaiViaGeminiFactory is the provider factory function for VertexAI via Gemini.
+// Supports ClientOptions for consistency, but skipVerifySSL is not used.
+func vertexaiViaGeminiFactory(ctx context.Context, opts ClientOptions) (Client, error) {
 	opt := VertexAIClientOptions{}
-
 	return NewVertexAIClient(ctx, opt)
 }
 

--- a/gollm/llamacpp.go
+++ b/gollm/llamacpp.go
@@ -33,8 +33,10 @@ func init() {
 	}
 }
 
-func llamacppFactory(ctx context.Context, u *url.URL) (Client, error) {
-	return NewLlamaCppClient(ctx)
+// llamacppFactory is the provider factory function for llama.cpp.
+// Supports ClientOptions for custom configuration, including skipVerifySSL.
+func llamacppFactory(ctx context.Context, opts ClientOptions) (Client, error) {
+	return NewLlamaCppClient(ctx, opts)
 }
 
 type LlamaCppClient struct {
@@ -52,7 +54,9 @@ type LlamaCppChat struct {
 
 var _ Client = &LlamaCppClient{}
 
-func NewLlamaCppClient(ctx context.Context) (*LlamaCppClient, error) {
+// NewLlamaCppClient creates a new client for llama.cpp.
+// Supports custom HTTP client and skipVerifySSL via ClientOptions.
+func NewLlamaCppClient(ctx context.Context, opts ClientOptions) (*LlamaCppClient, error) {
 	host := os.Getenv("LLAMACPP_HOST")
 	if host == "" {
 		host = "http://127.0.0.1:8080/"
@@ -64,9 +68,11 @@ func NewLlamaCppClient(ctx context.Context) (*LlamaCppClient, error) {
 	}
 	klog.Infof("using llama.cpp with base url %v", baseURL.String())
 
+	httpClient := createCustomHTTPClient(opts.SkipVerifySSL)
+
 	return &LlamaCppClient{
 		baseURL:    baseURL,
-		httpClient: http.DefaultClient,
+		httpClient: httpClient,
 	}, nil
 }
 

--- a/gollm/ollama.go
+++ b/gollm/ollama.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"net/url"
 
 	"github.com/ollama/ollama/api"
 	"k8s.io/klog/v2"
@@ -30,8 +29,10 @@ func init() {
 	}
 }
 
-func ollamaFactory(ctx context.Context, u *url.URL) (Client, error) {
-	return NewOllamaClient(ctx)
+// ollamaFactory is the provider factory function for Ollama.
+// Supports ClientOptions for custom configuration, including skipVerifySSL.
+func ollamaFactory(ctx context.Context, opts ClientOptions) (Client, error) {
+	return NewOllamaClient(ctx, opts)
 }
 
 const (
@@ -51,11 +52,16 @@ type OllamaChat struct {
 
 var _ Client = &OllamaClient{}
 
-func NewOllamaClient(ctx context.Context) (*OllamaClient, error) {
+// NewOllamaClient creates a new client for Ollama.
+// Supports custom HTTP client and skipVerifySSL via ClientOptions if the SDK supports it.
+func NewOllamaClient(ctx context.Context, opts ClientOptions) (*OllamaClient, error) {
+	// If the Ollama SDK supports custom HTTP client, inject it here.
+	// Otherwise, fallback to default environment-based client.
 	client, err := api.ClientFromEnvironment()
 	if err != nil {
 		return nil, err
 	}
+	// NOTE: If api.ClientFromEnvironment ever supports custom HTTP client, inject createCustomHTTPClient(opts.SkipVerifySSL) here.
 
 	return &OllamaClient{
 		client: client,

--- a/gollm/ollama.go
+++ b/gollm/ollama.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"github.com/ollama/ollama/api"
+	"github.com/ollama/ollama/envconfig"
 	"k8s.io/klog/v2"
 )
 
@@ -55,13 +56,9 @@ var _ Client = &OllamaClient{}
 // NewOllamaClient creates a new client for Ollama.
 // Supports custom HTTP client and skipVerifySSL via ClientOptions if the SDK supports it.
 func NewOllamaClient(ctx context.Context, opts ClientOptions) (*OllamaClient, error) {
-	// If the Ollama SDK supports custom HTTP client, inject it here.
-	// Otherwise, fallback to default environment-based client.
-	client, err := api.ClientFromEnvironment()
-	if err != nil {
-		return nil, err
-	}
-	// NOTE: If api.ClientFromEnvironment ever supports custom HTTP client, inject createCustomHTTPClient(opts.SkipVerifySSL) here.
+	// Create custom HTTP client with SSL verification option from client options
+	httpClient := createCustomHTTPClient(opts.SkipVerifySSL)
+	client := api.NewClient(envconfig.Host(), httpClient)
 
 	return &OllamaClient{
 		client: client,


### PR DESCRIPTION
- Add support for skipping SSL certificate verification via a new SkipVerifySSL flag, CLI option, and environment variable
- Refactor client factory functions to accept a unified ClientOptions struct, enabling custom configuration such as SkipVerifySSL
- Implement createCustomHTTPClient utility to provide HTTP clients with optional SSL verification
- Update provider client constructors (OpenAI, Azure OpenAI, Grok, LlamaCpp, Ollama) to support custom HTTP clients and SkipVerifySSL
- Improve error handling and variable declarations for clarity and consistency
- Minor code cleanup and reorganization for maintainability

fixed https://github.com/GoogleCloudPlatform/kubectl-ai/issues/211

cc @droot