### PR TITLE
Feature: add shields in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # kubectl-ai
 
+[![Go Report Card](https://goreportcard.com/badge/github.com/GoogleCloudPlatform/kubectl-ai)](https://goreportcard.com/report/github.com/GoogleCloudPlatform/kubectl-ai)
+![GitHub License](https://img.shields.io/github/license/GoogleCloudPlatform/kubectl-ai)
+[![GitHub stars](https://img.shields.io/github/stars/GoogleCloudPlatform/kubectl-ai.svg)](https://github.com/GoogleCloudPlatform/kubectl-ai/stargazers)
+
 `kubectl-ai` acts as an intelligent interface, translating user intent into
 precise Kubernetes operations, making Kubernetes management more accessible and
 efficient.


### PR DESCRIPTION
## Add Badges/Shields on README

It's a pretty common use case for OSS to have badges, they are convenient and make the repository be more _appealing_ if you could say so:

- `shields.io` uses [Creative Commons Zero](https://github.com/badges/shields/blob/master/LICENSE) License 

- `goreportcard` uses [Apache 2.0](https://github.com/gojp/goreportcard/blob/master/LICENSE) License.