### PR TITLE
Support custom tools

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -86,6 +86,7 @@ type Options struct {
 	ExtraPromptPaths       []string `json:"extraPromptPaths,omitempty"`
 	TracePath              string   `json:"tracePath,omitempty"`
 	RemoveWorkDir          bool     `json:"removeWorkDir,omitempty"`
+	ToolConfigPath         string   `json:"toolConfigPath,omitempty"`
 
 	// UserInterface is the type of user interface to use.
 	UserInterface UserInterface `json:"userInterface,omitempty"`
@@ -236,6 +237,12 @@ func run(ctx context.Context) error {
 		return fmt.Errorf("failed to load config file: %w", err)
 	}
 
+	// Load and register custom tools from config file
+	if err := tools.LoadAndRegisterCustomTools(opt.ToolConfigPath); err != nil {
+		// Log the error but continue execution, as custom tools are optional
+		klog.Warningf("Failed to load or register custom tools (path: %q): %v", opt.ToolConfigPath, err)
+	}
+
 	rootCmd, err := BuildRootCommand(&opt)
 	if err != nil {
 		return err
@@ -267,6 +274,7 @@ func (opt *Options) bindCLIFlags(f *pflag.FlagSet) error {
 	f.StringVar(&opt.ModelID, "model", opt.ModelID, "language model e.g. gemini-2.0-flash-thinking-exp-01-21, gemini-2.0-flash")
 	f.BoolVar(&opt.SkipPermissions, "skip-permissions", opt.SkipPermissions, "(dangerous) skip asking for confirmation before executing kubectl commands that modify resources")
 	f.BoolVar(&opt.MCPServer, "mcp-server", opt.MCPServer, "run in MCP server mode")
+	f.StringVar(&opt.ToolConfigPath, "custom-tools-config", opt.ToolConfigPath, "path to custom tools config file")
 	f.BoolVar(&opt.EnableToolUseShim, "enable-tool-use-shim", opt.EnableToolUseShim, "enable tool use shim")
 	f.BoolVar(&opt.Quiet, "quiet", opt.Quiet, "run in non-interactive mode, requires a query to be provided as a positional argument")
 

--- a/pkg/tools/custom_tool.go
+++ b/pkg/tools/custom_tool.go
@@ -1,0 +1,96 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tools
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/GoogleCloudPlatform/kubectl-ai/gollm"
+)
+
+// CustomToolConfig defines the structure for configuring a custom tool.
+type CustomToolConfig struct {
+	Name        string `yaml:"name"`
+	Description string `yaml:"description"`
+	Command     string `yaml:"command"`
+	CommandDesc string `yaml:"command_desc"`
+}
+
+// CustomTool implements the Tool interface for external commands.
+type CustomTool struct {
+	config CustomToolConfig
+}
+
+// NewCustomTool creates a new CustomTool instance.
+func NewCustomTool(config CustomToolConfig) (*CustomTool, error) {
+	if config.Name == "" {
+		return nil, fmt.Errorf("custom tool name cannot be empty")
+	}
+	if len(config.Command) == 0 {
+		return nil, fmt.Errorf("custom tool command cannot be empty for tool %q", config.Name)
+	}
+
+	return &CustomTool{config: config}, nil
+}
+
+// Name returns the tool's name.
+func (t *CustomTool) Name() string {
+	return t.config.Name
+}
+
+// Description returns the tool's description from its function definition.
+func (t *CustomTool) Description() string {
+	return t.config.Description
+}
+
+// FunctionDefinition returns the tool's function definition.
+func (t *CustomTool) FunctionDefinition() *gollm.FunctionDefinition {
+	return &gollm.FunctionDefinition{
+		Name:        t.Name(),
+		Description: t.Description(),
+		Parameters: &gollm.Schema{
+			Type: gollm.TypeObject,
+			Properties: map[string]*gollm.Schema{
+				"command": {
+					Type:        gollm.TypeString,
+					Description: t.config.CommandDesc,
+				},
+			},
+		},
+	}
+}
+
+// Run executes the external command defined for the custom tool.
+func (t *CustomTool) Run(ctx context.Context, args map[string]any) (any, error) {
+	command := strings.Fields(t.config.Command)
+	if len(command) == 0 {
+		return nil, fmt.Errorf("empty command")
+	}
+	cmdArgs := []string{}
+	if len(command) > 1 {
+		cmdArgs = command[1:]
+	}
+	workDir := ctx.Value(WorkDirKey).(string)
+
+	cmd := exec.CommandContext(ctx, command[0], cmdArgs...)
+	cmd.Dir = workDir
+	cmd.Env = os.Environ()
+
+	return executeCommand(cmd)
+}


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/kubectl-ai/issues/222

Usage: `kubectl-ai --custom-tools-config=<path to tools config>` (default location `~/.config/kubectl-ai/tools.yaml`)

Example tool config (this takes multiple custom tools):
```yaml
- name: nomos_status
  description: "Runs the 'nomos status' command to check Config Sync status on specified Kubernetes clusters."
  command: "nomos status"
  command_desc: "The nomos status command for Config Sync status on the cluster"
```
(Tool description gives LLM hint when to use the tool; command description is more about syntax and examples of command usage.)

Example result:
![Screenshot 2025-05-15 at 11 43 35 AM](https://github.com/user-attachments/assets/408d38d5-d9a6-47fe-a1da-4dd519231ec4)
![Screenshot 2025-05-15 at 11 43 49 AM](https://github.com/user-attachments/assets/f5028ff4-4d5f-4219-be52-afcdd59bce24)

Note that `kubectl-ai` can still answer questions without the tool. Adding custom tools enriches the answer. 
![Screenshot 2025-05-15 at 2 59 17 PM](https://github.com/user-attachments/assets/1cef1859-59ca-4261-80a1-b0a2cb1bbb59)

