### PR TITLE
ci: add workflow for k8s-bench evaluations on push/PR

### DIFF
--- a/.github/actions/kind-cluster-setup/action.yaml
+++ b/.github/actions/kind-cluster-setup/action.yaml
@@ -1,0 +1,19 @@
+name: Kind Cluster Setup
+description: "Sets up a Kind Kubernetes cluster and authenticates with GCP"
+inputs:
+  cluster_name:
+    description: "The name of the Kind cluster"
+    required: false
+    default: "periodic-eval-cluster"
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/checkout@v4
+    - name: Create k8s Kind Cluster
+      uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # @v1.12.0
+      with:
+        cluster_name: ${{ inputs.cluster_name }}
+    - uses: "google-github-actions/auth@v2"
+      with:
+        project_id: "sunilarora-fp"
+        workload_identity_provider: "projects/512195022720/locations/global/workloadIdentityPools/github/providers/kubectl-ai"

--- a/.github/workflows/ci-periodic.yaml
+++ b/.github/workflows/ci-periodic.yaml
@@ -36,14 +36,10 @@ jobs:
       id-token: "write"
     steps:
       - uses: actions/checkout@v4
-      - name: Create k8s Kind Cluster
-        uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # @v1.12.0
+      - name: Kind Cluster Setup
+        uses: ./.github/actions/kind-cluster-setup
         with:
           cluster_name: periodic-eval-cluster
-      - uses: "google-github-actions/auth@v2"
-        with:
-          project_id: "sunilarora-fp"
-          workload_identity_provider: "projects/512195022720/locations/global/workloadIdentityPools/github/providers/kubectl-ai"
       - name: Run an easy eval
         run: |
           TEST_ARGS="--llm-provider vertexai --models gemini-2.5-pro-preview-05-06 --enable-tool-use-shim=false --task-pattern=scale-" ./dev/ci/periodics/run-evals.sh

--- a/.github/workflows/k8s-bench-evals.yaml
+++ b/.github/workflows/k8s-bench-evals.yaml
@@ -1,0 +1,48 @@
+# Workflow to run k8s-bench evaluations on push and PR
+name: k8s-bench-evals
+
+on:
+  pull_request:
+    paths:
+      - 'k8s-bench/tasks/**'
+  push:
+    branches: [main]
+    paths:
+      - 'k8s-bench/tasks/**'
+
+jobs:
+  evals:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Node.js runtime
+        run: |
+          apt-get update
+          apt-get install -y curl gnupg
+          curl -fsSL https://deb.nodesource.com/setup_18.x | bash -
+          apt-get install -y nodejs
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+      - name: Install Docker CLI
+        run: |
+          apt-get update
+          apt-get install -y docker.io
+      - name: Set up Kind cluster
+        uses: engineerd/setup-kind@v0.6.1
+      - name: Run k8s-bench evaluations
+        run: |
+          go run ./k8s-bench/main.go run \
+            --tasks-dir=k8s-bench/tasks \
+            --output-dir=eval-results \
+            --concurrency=1
+      - name: Upload results
+        uses: actions/upload-artifact@v3
+        with:
+          name: k8s-bench-results
+          path: eval-results

--- a/.github/workflows/k8s-bench-evals.yaml
+++ b/.github/workflows/k8s-bench-evals.yaml
@@ -20,9 +20,8 @@ on:
   workflow_dispatch:
     inputs:
       task_pattern:
-        description: "Task name or glob pattern to test (e.g. scale-*, my-task)"
+        description: "Task name or glob pattern to test (must not be '*' or empty; e.g. scale-my-task, scale-foo)"
         required: true
-        default: "scale-"
 
 jobs:
   run-eval:
@@ -32,11 +31,17 @@ jobs:
       contents: "read"
       id-token: "write"
     steps:
+      - name: Validate task_pattern input
+        run: |
+          if [[ -z "${{ github.event.inputs.task_pattern }}" || "${{ github.event.inputs.task_pattern }}" == "*" || "${{ github.event.inputs.task_pattern }}" == "all" ]]; then
+            echo "Error: You must provide a specific task name or pattern. Wildcards or empty values are not allowed."
+            exit 1
+          fi
       - uses: actions/checkout@v4
       - name: Kind Cluster Setup
         uses: ./.github/actions/kind-cluster-setup
         with:
-          cluster_name: periodic-eval-cluster
+          cluster_name: ${{ github.head_ref || github.ref_name }}
       - name: Run evals
         # In the future, more options (provider/model/tool-use-shim) may be user-selectable.
         # For now, these are fixed for CI safety and consistency.

--- a/.github/workflows/k8s-bench-evals.yaml
+++ b/.github/workflows/k8s-bench-evals.yaml
@@ -1,48 +1,57 @@
-# Workflow to run k8s-bench evaluations on push and PR
-name: k8s-bench-evals
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This workflow allows PR owners who add new eval tasks to manually run tests on their changes using the GitHub Actions UI.
+#It is intended for self-service validation of new or modified evals before merging.
+name: On-Demand k8s-bench Eval Test
 
 on:
-  pull_request:
-    paths:
-      - 'k8s-bench/tasks/**'
-  push:
-    branches: [main]
-    paths:
-      - 'k8s-bench/tasks/**'
+  workflow_dispatch:
+    inputs:
+      task_pattern:
+        description: "Task name or glob pattern to test (e.g. scale-*, my-task)"
+        required: true
+        default: "scale-"
 
 jobs:
-  evals:
+  run-eval:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: "read"
+      id-token: "write"
     steps:
       - uses: actions/checkout@v4
-      - name: Install Node.js runtime
-        run: |
-          apt-get update
-          apt-get install -y curl gnupg
-          curl -fsSL https://deb.nodesource.com/setup_18.x | bash -
-          apt-get install -y nodejs
-      - name: Set up Node.js
-        uses: actions/setup-node@v3
+      - name: Kind Cluster Setup
+        uses: ./.github/actions/kind-cluster-setup
         with:
-          node-version: '18'
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: 'go.mod'
-      - name: Install Docker CLI
+          cluster_name: periodic-eval-cluster
+      - name: Run evals
+        # In the future, more options (provider/model/tool-use-shim) may be user-selectable.
+        # For now, these are fixed for CI safety and consistency.
+        env:
+          TEST_ARGS: >-
+            --llm-provider ${{ github.event.inputs.llm_provider || 'vertexai' }} \
+            --models ${{ github.event.inputs.model || 'gemini-2.5-pro-preview-05-06' }} \
+            --enable-tool-use-shim=${{ github.event.inputs.enable_tool_use_shim || 'false' }} \
+            --task-pattern=${{ github.event.inputs.task_pattern || 'scale-' }}
         run: |
-          apt-get update
-          apt-get install -y docker.io
-      - name: Set up Kind cluster
-        uses: engineerd/setup-kind@v0.6.1
-      - name: Run k8s-bench evaluations
+          ./dev/ci/periodics/run-evals.sh
+      - name: Analyse results
         run: |
-          go run ./k8s-bench/main.go run \
-            --tasks-dir=k8s-bench/tasks \
-            --output-dir=eval-results \
-            --concurrency=1
-      - name: Upload results
-        uses: actions/upload-artifact@v3
-        with:
-          name: k8s-bench-results
-          path: eval-results
+          ./dev/ci/periodics/analyze-evals.sh
+          cat ${{ github.workspace }}/.build/k8s-bench.md >> ${GITHUB_STEP_SUMMARY}
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: false


### PR DESCRIPTION
### PR Summary
This update introduces a new GitHub workflow (`k8s-bench-evals.yaml`) designed to facilitate self-service, on-demand execution of Kubernetes benchmark evaluations. It provides manual trigger capabilities, allowing PR owners or developers to test specific evaluation tasks before merging, thereby ensuring robustness and correctness of new or modified evaluations.

### Affected Modules
- Workflow configuration (`.github/workflows/k8s-bench-evals.yaml`)
- Custom actions for setting up Kind clusters (`.github/actions/kind-cluster-setup`)
- Evaluation scripts (`run-evals.sh` and `analyze-evals.sh`)

### Key Details
- Workflow is triggered manually via `workflow_dispatch`.
- Allows user input for `task_pattern`, enabling targeted testing of specific evaluation tasks.
- Uses a custom setup action for creating a Kind Kubernetes cluster.
- Runs `run-evals.sh` with preconfigured environment variables for consistent testing.
- Post-processing includes result analysis and appending the evaluation report to GitHub’s step summary.
- Implements concurrency control based on workflow or branch to prevent overlapping runs.

### Potential Impacts
- Empowers developers to validate new evaluation tasks in isolation before merging.
- Enhances testing consistency via controlled environment and fixed parameters.
- Requires users to follow prescribed input patterns to avoid misconfigurations.
- Adds manual step, so it is unsuitable for fully automated testing pipelines.

