### PR TITLE
fix(tools): Use exec.LookPath to find bash executable before running bash commands

### DIFF
--- a/pkg/tools/bash_tool.go
+++ b/pkg/tools/bash_tool.go
@@ -24,15 +24,24 @@ import (
 	"strings"
 
 	"github.com/GoogleCloudPlatform/kubectl-ai/gollm"
+	"k8s.io/klog/v2"
 )
+
+var bashBin string
 
 func init() {
+	// Find the bash executable path using exec.LookPath.
+	// On some systems (like NixOS), executables might not be in standard locations like /bin/bash.
+	var err error
+	bashBin, err = exec.LookPath("bash")
+	if err != nil {
+		log := klog.FromContext(context.Background())
+		log.Info("Warning: 'bash' not found in PATH, defaulting to /bin/bash", "error", err)
+		bashBin = "/bin/bash"
+	}
+
 	RegisterTool(&BashTool{})
 }
-
-const (
-	bashBin = "/bin/bash"
-)
 
 // expandShellVar expands shell variables and syntax using bash
 func expandShellVar(value string) (string, error) {

--- a/pkg/tools/kubectl_tool.go
+++ b/pkg/tools/kubectl_tool.go
@@ -90,7 +90,7 @@ func runKubectlCommand(ctx context.Context, command, workDir, kubeconfig string)
 	if runtime.GOOS == "windows" {
 		cmd = exec.CommandContext(ctx, os.Getenv("COMSPEC"), "/c", command)
 	} else {
-		cmd = exec.CommandContext(ctx, bashBin, "-c", command)
+		cmd = exec.CommandContext(ctx, lookupBashBin(), "-c", command)
 	}
 	cmd.Env = os.Environ()
 	cmd.Dir = workDir


### PR DESCRIPTION
Fixes #228

Find the bash executable using `exec.LookPath` instead of hardcoding `/bin/bash`. Falls back to `/bin/bash` if not found in PATH. Improves compatibility on systems where bash might be installed in a non-standard location.

On some systems (e.g. NixOS), executables might not be in standard locations like /bin/bash.
