### PR TITLE
Lazy initialization of input readers and evals

### DIFF
--- a/dev/ci/presubmits/verify-autogen.sh
+++ b/dev/ci/presubmits/verify-autogen.sh
@@ -25,7 +25,7 @@ dev/tasks/generate-github-actions.sh
 
 changes=$(git status --porcelain)
 if [[ -n "${changes}" ]]; then
-  echo "FAIL: Changes detected from dev/tasks/generate-github-actions:"
+  echo "FAIL: Changes detected from dev/tasks/generate-github-actions.sh:"
   git diff | head -n60
   echo "${changes}"
   exit 1

--- a/dev/ci/presubmits/verify-format.sh
+++ b/dev/ci/presubmits/verify-format.sh
@@ -21,11 +21,11 @@ set -o pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd ${REPO_ROOT}
 
-dev/tasks/format
+dev/tasks/format.sh
 
 changes=$(git status --porcelain)
 if [[ -n "${changes}" ]]; then
-  echo "FAIL: Changes detected from dev/tasks/format:"
+  echo "FAIL: Changes detected from dev/tasks/format.sh:"
   git diff | head -n60
   echo "${changes}"
   exit 1

--- a/dev/ci/presubmits/verify-gomod.sh
+++ b/dev/ci/presubmits/verify-gomod.sh
@@ -21,11 +21,11 @@ set -o pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd ${REPO_ROOT}
 
-dev/tasks/gomod
+dev/tasks/gomod.sh
 
 changes=$(git status --porcelain)
 if [[ -n "${changes}" ]]; then
-  echo "FAIL: Changes detected from dev/tasks/gomod:"
+  echo "FAIL: Changes detected from dev/tasks/gomod.sh:"
   git diff | head -n60
   echo "${changes}"
   exit 1

--- a/dev/tasks/generate-github-actions.sh
+++ b/dev/tasks/generate-github-actions.sh
@@ -53,7 +53,8 @@ EOF
 
 
 for f in $(find dev/ci/presubmits -type f | sort ); do
-    name=$(basename ${f})
+    filename=$(basename ${f})
+    name="${filename%.*}"
 
 cat >> ${REPO_ROOT}/.github/workflows/ci-presubmit.yaml <<EOF
 


### PR DESCRIPTION
Two separate but slightly related changes (captured in separate commits)

## Lazy initializations of Input readers (tty and readline)

Initialize these readers only when needed. Two benefits:
1. We won't setup these when running in non-interactive mode (`--quiet`)
2. k8s-bench feeds the interactive script on stdin, that forces the kubectl-ai to use tty for input when the input is through stdin. And github actions don't make /dev/tty available and that causes `k8s-bench` to fail when running in CI (github actions)

CI changes
1. Added step to run lightweight evals (two tasks related to scaling)
2. Added a workflow for periodic evaluation

Note: I am using keyless setup for authenticating github actions with GCP's vertexai platform. I expect a few bumps. I have tested this in my own fork, but let see how it goes here. 

*UPDATE*: Had to remove the presubmit checks because I am running into permission issue. Will introduce that as separate PR.