### PR TITLE
refactor(k8s-bench/tasks): update shebang in k8s-bench task scripts

### DIFF
--- a/k8s-bench/tasks/create-network-policy/cleanup.sh
+++ b/k8s-bench/tasks/create-network-policy/cleanup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Delete the namespaces which will also delete all resources in them
 kubectl delete namespace ns1 --ignore-not-found

--- a/k8s-bench/tasks/create-network-policy/setup.sh
+++ b/k8s-bench/tasks/create-network-policy/setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Cleanup existing namespaces if they exist
 kubectl delete namespace ns1 --ignore-not-found

--- a/k8s-bench/tasks/create-network-policy/verify.sh
+++ b/k8s-bench/tasks/create-network-policy/verify.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Check if NetworkPolicy exists
 if ! kubectl get networkpolicy np -n ns1 &>/dev/null; then

--- a/k8s-bench/tasks/create-pod-mount-configmaps/cleanup.sh
+++ b/k8s-bench/tasks/create-pod-mount-configmaps/cleanup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 kubectl delete namespace color-size-settings --ignore-not-found
 echo "Cleanup completed" 

--- a/k8s-bench/tasks/create-pod-mount-configmaps/setup.sh
+++ b/k8s-bench/tasks/create-pod-mount-configmaps/setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Delete the namespace if it exists to ensure a clean state
 kubectl delete namespace color-size-settings --ignore-not-found

--- a/k8s-bench/tasks/create-pod-mount-configmaps/verify.sh
+++ b/k8s-bench/tasks/create-pod-mount-configmaps/verify.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 NAMESPACE="color-size-settings"
 

--- a/k8s-bench/tasks/create-pod-resources-limits/cleanup.sh
+++ b/k8s-bench/tasks/create-pod-resources-limits/cleanup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Delete the namespace which will also delete all resources in it
 kubectl delete namespace limits-test --ignore-not-found

--- a/k8s-bench/tasks/create-pod-resources-limits/setup.sh
+++ b/k8s-bench/tasks/create-pod-resources-limits/setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Delete the namespace if it exists to ensure a clean state
 kubectl delete namespace limits-test --ignore-not-found

--- a/k8s-bench/tasks/create-pod-resources-limits/verify.sh
+++ b/k8s-bench/tasks/create-pod-resources-limits/verify.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Check if namespace exists
 if ! kubectl get namespace limits-test &>/dev/null; then

--- a/k8s-bench/tasks/create-pod/cleanup.sh
+++ b/k8s-bench/tasks/create-pod/cleanup.sh
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/usr/bin/env bash
 kubectl delete pod web-server -n create-pod-test --ignore-not-found

--- a/k8s-bench/tasks/create-pod/setup.sh
+++ b/k8s-bench/tasks/create-pod/setup.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 kubectl delete namespace create-pod-test --ignore-not-found
 kubectl create namespace create-pod-test

--- a/k8s-bench/tasks/create-pod/verify.sh
+++ b/k8s-bench/tasks/create-pod/verify.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Wait for pod to be running with kubectl wait
 if kubectl wait --for=condition=Ready pod/web-server -n create-pod-test --timeout=30s; then
     exit 0

--- a/k8s-bench/tasks/fix-crashloop/cleanup.sh
+++ b/k8s-bench/tasks/fix-crashloop/cleanup.sh
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/usr/bin/env bash
 kubectl delete namespace crashloop-test 

--- a/k8s-bench/tasks/fix-crashloop/setup.sh
+++ b/k8s-bench/tasks/fix-crashloop/setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 kubectl delete namespace crashloop-test --ignore-not-found
 # Create namespace and a deployment with an invalid command that will cause crashloop
 kubectl create namespace crashloop-test

--- a/k8s-bench/tasks/fix-crashloop/verify.sh
+++ b/k8s-bench/tasks/fix-crashloop/verify.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Wait for pod to be ready
 if kubectl wait --for=condition=Ready pod -l app=nginx -n crashloop-test --timeout=25s; then
     # Get current restart count

--- a/k8s-bench/tasks/fix-image-pull/cleanup.sh
+++ b/k8s-bench/tasks/fix-image-pull/cleanup.sh
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/usr/bin/env bash
 kubectl delete namespace debug 

--- a/k8s-bench/tasks/fix-image-pull/setup.sh
+++ b/k8s-bench/tasks/fix-image-pull/setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Create namespace and a deployment with an invalid image that will cause ImagePullBackOff
 kubectl delete namespace debug --ignore-not-found
 kubectl create namespace debug

--- a/k8s-bench/tasks/fix-image-pull/verify.sh
+++ b/k8s-bench/tasks/fix-image-pull/verify.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Wait for pod to be ready
 if kubectl wait --for=condition=Ready pod -l app=nginx -n debug --timeout=25s; then
     # Get current restart count

--- a/k8s-bench/tasks/fix-probes/cleanup.sh
+++ b/k8s-bench/tasks/fix-probes/cleanup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Delete the namespace which will remove all resources created for this task
 kubectl delete namespace health-check --ignore-not-found

--- a/k8s-bench/tasks/fix-probes/setup.sh
+++ b/k8s-bench/tasks/fix-probes/setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Delete namespace if exists and create a fresh one
 kubectl delete namespace health-check --ignore-not-found

--- a/k8s-bench/tasks/fix-probes/verify.sh
+++ b/k8s-bench/tasks/fix-probes/verify.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Check if the pod is in Running state with Ready status
 echo "Checking if the pod is running and ready..."

--- a/k8s-bench/tasks/fix-service-routing/cleanup.sh
+++ b/k8s-bench/tasks/fix-service-routing/cleanup.sh
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/usr/bin/env bash
 kubectl delete namespace web 

--- a/k8s-bench/tasks/fix-service-routing/setup.sh
+++ b/k8s-bench/tasks/fix-service-routing/setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Create namespace and deployment with one set of labels
 kubectl delete namespace web --ignore-not-found
 kubectl create namespace web

--- a/k8s-bench/tasks/fix-service-routing/verify.sh
+++ b/k8s-bench/tasks/fix-service-routing/verify.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Check if service has endpoints
 endpoints=$(kubectl get endpoints nginx -n web -o jsonpath='{.subsets[0].addresses}')
 if [[ ! -z "$endpoints" ]]; then

--- a/k8s-bench/tasks/horizontal-pod-autoscaler/cleanup.sh
+++ b/k8s-bench/tasks/horizontal-pod-autoscaler/cleanup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Tear down namespace and HPA resources
 kubectl delete namespace hpa-test --ignore-not-found
 exit 0

--- a/k8s-bench/tasks/horizontal-pod-autoscaler/setup.sh
+++ b/k8s-bench/tasks/horizontal-pod-autoscaler/setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Initialize namespace and deployment with CPU load generator
 kubectl delete namespace hpa-test --ignore-not-found
 kubectl create namespace hpa-test

--- a/k8s-bench/tasks/horizontal-pod-autoscaler/verify.sh
+++ b/k8s-bench/tasks/horizontal-pod-autoscaler/verify.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Wait until HPA scales above 1 replica
 if kubectl wait hpa/web-app -n hpa-test --for=condition=ScalingActive --timeout=120s; then
   exit 0

--- a/k8s-bench/tasks/list-images-for-pods/cleanup.sh
+++ b/k8s-bench/tasks/list-images-for-pods/cleanup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -o errexit
 set -o nounset

--- a/k8s-bench/tasks/list-images-for-pods/setup.sh
+++ b/k8s-bench/tasks/list-images-for-pods/setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -o errexit
 set -o nounset

--- a/k8s-bench/tasks/list-images-for-pods/verify.sh
+++ b/k8s-bench/tasks/list-images-for-pods/verify.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -o errexit
 set -o nounset

--- a/k8s-bench/tasks/rolling-update-deployment/cleanup.sh
+++ b/k8s-bench/tasks/rolling-update-deployment/cleanup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Tear down namespace and deployment
 kubectl delete namespace rollout-test --ignore-not-found
 exit 0

--- a/k8s-bench/tasks/rolling-update-deployment/setup.sh
+++ b/k8s-bench/tasks/rolling-update-deployment/setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Initialize namespace and deployment with the old image
 kubectl delete namespace rollout-test --ignore-not-found
 kubectl create namespace rollout-test

--- a/k8s-bench/tasks/rolling-update-deployment/verify.sh
+++ b/k8s-bench/tasks/rolling-update-deployment/verify.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Wait for rollout to complete
 kubectl rollout status deployment/web-app -n rollout-test --timeout=120s || exit 1
 

--- a/k8s-bench/tasks/scale-deployment/cleanup.sh
+++ b/k8s-bench/tasks/scale-deployment/cleanup.sh
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/usr/bin/env bash
 kubectl delete namespace scale-test 

--- a/k8s-bench/tasks/scale-deployment/setup.sh
+++ b/k8s-bench/tasks/scale-deployment/setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Create namespace and a deployment with initial replicas
 kubectl delete namespace scale-test --ignore-not-found
 kubectl create namespace scale-test

--- a/k8s-bench/tasks/scale-deployment/verify.sh
+++ b/k8s-bench/tasks/scale-deployment/verify.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Wait for deployment to scale to 2 replicas with kubectl wait
 if kubectl wait --for=condition=Available=True --timeout=30s deployment/web-app -n scale-test; then
     # Verify the replica count is exactly 2

--- a/k8s-bench/tasks/scale-down-deployment/cleanup.sh
+++ b/k8s-bench/tasks/scale-down-deployment/cleanup.sh
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/usr/bin/env bash
 kubectl delete namespace scale-down-test 

--- a/k8s-bench/tasks/scale-down-deployment/setup.sh
+++ b/k8s-bench/tasks/scale-down-deployment/setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Create namespace and a deployment with initial replicas
 kubectl delete namespace scale-down-test --ignore-not-found
 kubectl create namespace scale-down-test

--- a/k8s-bench/tasks/scale-down-deployment/verify.sh
+++ b/k8s-bench/tasks/scale-down-deployment/verify.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Wait for deployment to scale down to 2 replicas with kubectl wait
 if kubectl wait --for=condition=Available=True --timeout=30s deployment/web-service -n scale-down-test; then
     # Verify the replica count is exactly 2

--- a/k8s-bench/tasks/statefulset-lifecycle/cleanup.sh
+++ b/k8s-bench/tasks/statefulset-lifecycle/cleanup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Tear down namespace and StatefulSet resources
 kubectl delete namespace statefulset-test --ignore-not-found
 exit 0

--- a/k8s-bench/tasks/statefulset-lifecycle/setup.sh
+++ b/k8s-bench/tasks/statefulset-lifecycle/setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Teardown any existing namespace
 kubectl delete namespace statefulset-test --ignore-not-found
 

--- a/k8s-bench/tasks/statefulset-lifecycle/verify.sh
+++ b/k8s-bench/tasks/statefulset-lifecycle/verify.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Verify only db-0 and db-1 remain
 for pod in db-0 db-1; do


### PR DESCRIPTION
### PR Summary

This pull request introduces similar changes as made for #230  , it updates the shebang line in all k8s-bench task scripts from `#!/bin/bash` to `#!/usr/bin/env bash`. This change enhances script portability by allowing the system to locate the `bash` executable via the user's PATH, rather than depending on a fixed path like `/bin/bash`.

### Affected Modules

*   k8s-bench/tasks/ (all setup, cleanup, and verify shell scripts)

### Key Details

*   Replaced `#!/bin/bash` with `#!/usr/bin/env bash` in numerous shell scripts.
*   Aims to improve script execution reliability across varying system configurations.

### Potential Impacts

*   Scripts should now be more robust against environments where `bash` is installed in a non-standard location.
*   No functional changes to the core logic of the task scripts are introduced.