### PR TITLE
fix(ci): Ensure job runs only for the correct repository

### DIFF
--- a/.github/workflows/ci-periodic.yaml
+++ b/.github/workflows/ci-periodic.yaml
@@ -28,6 +28,7 @@ on:
         default: "Manual run via UI"
 jobs:
   run-eval:
+    if: github.repository == 'GoogleCloudPlatform/kubectl-ai'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     # Add "id-token" with the intended permissions.


### PR DESCRIPTION
This pull request makes a small change to the `.github/workflows/ci-periodic.yaml` file by adding a condition to the `run-eval` job. The job will now only run if the repository is `GoogleCloudPlatform/kubectl-ai`.