### PR TITLE
Add modifies_resource parameter to custom tool

### DIFF
--- a/pkg/tools/custom_tool.go
+++ b/pkg/tools/custom_tool.go
@@ -71,6 +71,15 @@ func (t *CustomTool) FunctionDefinition() *gollm.FunctionDefinition {
 					Type:        gollm.TypeString,
 					Description: t.config.CommandDesc,
 				},
+				"modifies_resource": {
+					Type: gollm.TypeString,
+					Description: `Whether the command modifies a kubernetes resource.
+Possible values:
+- "yes" if the command modifies a resource
+- "no" if the command does not modify a resource
+- "unknown" if the command's effect on the resource is unknown
+`,
+				},
 			},
 		},
 	}


### PR DESCRIPTION
This allows skipping confirmation for read-only tools, e.g. 

```shell
> kubectl-ai

  Hey there, what can I help you with today?                                  
                                                                                                                                                     
                                                                                                                                                     
>>> What's the status of my Config Sync?                                                                                                             
  Running: nomos_status(modifies_resource=no)
```