### PR TITLE
ci(workflows): add random task selection in CI periodic job

### DIFF
--- a/.github/workflows/ci-periodic.yaml
+++ b/.github/workflows/ci-periodic.yaml
@@ -45,9 +45,16 @@ jobs:
         with:
           project_id: "sunilarora-fp"
           workload_identity_provider: "projects/512195022720/locations/global/workloadIdentityPools/github/providers/kubectl-ai"
-      - name: Run an easy eval
+      - name: List and select a random task
+        id: random-task
         run: |
-          TEST_ARGS="--llm-provider vertexai --models gemini-2.5-pro-preview-05-06 --enable-tool-use-shim=false --task-pattern=scale-" ./dev/ci/periodics/run-evals.sh
+          TASKS=($(ls -d k8s-bench/tasks/*/ | xargs -n1 basename))
+          SELECTED_TASK=${TASKS[$RANDOM % ${#TASKS[@]}]}
+          echo "Selected task: $SELECTED_TASK"
+          echo "selected_task=$SELECTED_TASK" >> $GITHUB_OUTPUT
+      - name: Run eval with random task
+        run: |
+          TEST_ARGS="--llm-provider vertexai --models gemini-2.5-pro-preview-05-06 --enable-tool-use-shim=false --task-pattern=^${{ steps.random-task.outputs.selected_task }}$" ./dev/ci/periodics/run-evals.sh
       - name: Analyse results
         run: |
           ./dev/ci/periodics/analyze-evals.sh


### PR DESCRIPTION
## Summary
This update refactors the CI pipeline in `.github/workflows/ci-periodic.yaml` to select a random task dynamically from available task directories. Instead of running a fixed eval, it now lists tasks under `k8s-bench/tasks/`, randomly picks one, and executes evaluation with that selected task. This enhances testing coverage across diverse tasks and reduces manual maintenance of specific task configurations.

## Affected Modules
- `.github/workflows/ci-periodic.yaml`: Workflow configuration for CI periodic jobs.

## Key Details
- **Task Listing:** Uses `ls` to list all subdirectories in `k8s-bench/tasks/`.
- **Random Selection:** Picks a task at random using Bash's `$RANDOM` and array indexing.
- **Output Handling:** Stores the selected task in `GITHUB_OUTPUT` for subsequent steps.
- **Eval Execution:** Runs evaluation with the randomly selected task using the established testing script.
- **Analysis Step:** Continues to run post-evaluation analysis as before.

## Potential Impacts
- Introduces variability in CI runs, improving robustness across different tasks.
- Ensures broader test coverage by automatically testing diverse configurations.
- Slight nondeterminism may affect reproducibility logs; consider pinning in specific cases.

## Related PR

https://github.com/GoogleCloudPlatform/kubectl-ai/pull/229