### PR TITLE
Feat/#252 version handler

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -23,6 +23,11 @@ builds:
       - windows
       - darwin
     main: ./cmd
+    ldflags:
+      - -s -w
+      - -X main.version={{.Version}}
+      - -X main.commit={{.Commit}}
+      - -X main.date={{.Date}}
 
 archives:
   - formats: [tar.gz]

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -490,7 +490,7 @@ func (s *session) repl(ctx context.Context, initialQuery string) error {
 		case query == "clear":
 			s.ui.ClearScreen()
 		case query == "exit" || query == "quit":
-			// s.ui.RenderOutput(ctx, "Allright...bye.\n")
+			// s.ui.RenderOutput(ctx, "Alright...bye.\n")
 			return nil
 		default:
 			if err := s.answerQuery(ctx, query); err != nil {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -63,7 +63,7 @@ func BuildRootCommand(opt *Options) (*cobra.Command, error) {
 		Use:   "version",
 		Short: "Print the version number of kubectl-ai",
 		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Printf("kubectl-ai version: %s\ncommit: %s\ndate: %s\n", version, commit, date)
+			fmt.Printf("version: %s\ncommit: %s\ndate: %s\n", version, commit, date)
 			os.Exit(0)
 		},
 	})

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -59,6 +59,15 @@ func BuildRootCommand(opt *Options) (*cobra.Command, error) {
 		},
 	}
 
+	rootCmd.AddCommand(&cobra.Command{
+		Use:   "version",
+		Short: "Print the version number of kubectl-ai",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Printf("kubectl-ai version: %s\ncommit: %s\ndate: %s\n", version, commit, date)
+			os.Exit(0)
+		},
+	})
+
 	if err := opt.bindCLIFlags(rootCmd.Flags()); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Improve Overall Release and Version handling
> _(fixes #252 )_

### Summary

- Added a new `version` command to the CLI outside of the repl. Now you can run `kubectl-ai version` to see the current version, commit, and build date of the tool without the need to provide env variables. - Updated our release process so that every build now includes this version information automatically. This is set up in our GoReleaser configuration. previous [Releases](https://github.com/GoogleCloudPlatform/kubectl-ai/actions/workflows/release.yaml) still reflected default config:

```go
var (
	version = "dev"
	commit  = "none"
	date    = "unknown"
)
```

### Tests

- Built the project using GoReleaser locally in snapshot mode to simulate a mock a _CI/CD Release_ 
https://github.com/GoogleCloudPlatform/kubectl-ai/blob/b8e4c66e27f3235e0999c1d908eb98bae448b700/.github/workflows/release.yaml#L26-L33

- Extracted the built binary from the dist folder.
- Ran `./kubectl-ai version` and confirmed it prints out the correct version, commit, and date, like this:

 ```
❯ dist/kubectl-ai version
kubectl-ai version: 0.0.0-SNAPSHOT-b8e4c66
commit: b8e4c66e27f3235e0999c1d908eb98bae448b700
date: 2025-05-20T17:07:50Z
  ```

> [!WARNING]
> Until a Release is released, the state of the variable will remain as the zero/current value:

```
❯ ./kubectl-ai version
kubectl-ai version: dev
commit: none
date: unknown
```