### PR TITLE
fix: ignore when the tool config path is not exit

### DIFF
--- a/pkg/tools/tools.go
+++ b/pkg/tools/tools.go
@@ -190,6 +190,10 @@ func ToolResultToMap(result any) (map[string]any, error) {
 func LoadAndRegisterCustomTools(configPath string) error {
 	pathInfo, err := os.Stat(configPath)
 	if err != nil {
+		if os.IsNotExist(err) {
+			// ignore
+			return nil
+		}
 		return fmt.Errorf("failed to describe config file %s: %w", configPath, err)
 	}
 


### PR DESCRIPTION
### Description

Ignore when the tool config path does not exist to avoid unnecessary warning logs

### Related Issue

fix #254