### PR TITLE
FIX | Stop Agentic Loop and Await User Input When Tool Call is Declined

### DIFF
--- a/pkg/agent/conversation.go
+++ b/pkg/agent/conversation.go
@@ -259,9 +259,16 @@ func (a *Conversation) RunOneRound(ctx context.Context, query string) error {
 				case "2":
 					a.SkipPermissions = true
 				case "3":
-					a.doc.AddBlock(ui.NewAgentTextBlock().WithText("Operation was skipped."))
-					observation := fmt.Sprintf("User didn't approve running %q.\n", call.Name)
-					currChatContent = append(currChatContent, observation)
+					a.doc.AddBlock(ui.NewAgentTextBlock().WithText("Operation was skipped. User declined to run this operation."))
+					currChatContent = append(currChatContent, gollm.FunctionCallResult{
+						ID:   call.ID,
+						Name: call.Name,
+						Result: map[string]any{
+							"error":     "User declined to run this operation.",
+							"status":    "declined",
+							"retryable": false,
+						},
+					})
 					continue
 				default:
 					// This case should technically not be reachable due to AskForConfirmation loop
@@ -312,6 +319,28 @@ func (a *Conversation) RunOneRound(ctx context.Context, query string) error {
 	errorBlock := ui.NewErrorBlock().SetText(fmt.Sprintf("Sorry, couldn't complete the task after %d iterations.\n", maxIterations))
 	a.doc.AddBlock(errorBlock)
 	return fmt.Errorf("max iterations reached")
+}
+
+// hashArgs creates a simple hash string for the arguments map (order-insensitive, stable)
+func hashArgs(args map[string]any) string {
+	if len(args) == 0 {
+		return ""
+	}
+	var keys []string
+	for k := range args {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	var sb strings.Builder
+	for _, k := range keys {
+		v := args[k]
+		// Only hash simple types for now
+		sb.WriteString(k)
+		sb.WriteString(":")
+		sb.WriteString(fmt.Sprintf("%v", v))
+		sb.WriteString(";")
+	}
+	return sb.String()
 }
 
 // toResult converts an arbitrary result to a map[string]any

--- a/pkg/agent/conversation.go
+++ b/pkg/agent/conversation.go
@@ -321,42 +321,6 @@ func (a *Conversation) RunOneRound(ctx context.Context, query string) error {
 	return fmt.Errorf("max iterations reached")
 }
 
-// hashArgs creates a simple hash string for the arguments map (order-insensitive, stable)
-func hashArgs(args map[string]any) string {
-	if len(args) == 0 {
-		return ""
-	}
-	var keys []string
-	for k := range args {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-	var sb strings.Builder
-	for _, k := range keys {
-		v := args[k]
-		// Only hash simple types for now
-		sb.WriteString(k)
-		sb.WriteString(":")
-		sb.WriteString(fmt.Sprintf("%v", v))
-		sb.WriteString(";")
-	}
-	return sb.String()
-}
-
-// toResult converts an arbitrary result to a map[string]any
-func toResult(v any) (map[string]any, error) {
-	b, err := json.Marshal(v)
-	if err != nil {
-		return nil, fmt.Errorf("converting result to json: %w", err)
-	}
-
-	m := make(map[string]any)
-	if err := json.Unmarshal(b, &m); err != nil {
-		return nil, fmt.Errorf("converting json result to map: %w", err)
-	}
-	return m, nil
-}
-
 // generateFromTemplate generates a prompt for LLM. It uses the prompt from the provides template file or default.
 func (a *Conversation) generatePrompt(_ context.Context, defaultPromptTemplate string, data PromptData) (string, error) {
 	promptTemplate := defaultPromptTemplate


### PR DESCRIPTION
# Summary  
Closes #144 , if a user declines a tool operation during (selects "3" in the confirmation prompt),https://github.com/GoogleCloudPlatform/kubectl-ai/blob/a5ea5cbb413e5d3dfaf1c80ac68ebe1fdcfd3261/pkg/agent/conversation.go#L261-L265
This causes OpenAI-compatible providers to error, as their protocol requires a tool message for every tool_call during streaming requests, even if the operation is skipped.

### Key Changes

- **On user decline (option "3") for a tool call:**
  - The agent now appends a tool message (`gollm.FunctionCallResult`) with `status: "declined"` and an error message to `currChatContent`.
   - We append `call.ID & call.Name` to comply with openai's api
  

- **Result:**  
  - The LLM is always informed of the user's decision, and the protocol requirement for tool message responses is met, even when the user declines an operation.

# Test
```
❯ ./kubectl-ai --llm-provider=openai --model=gpt-4o-mini-2024-07-18 "can you create a pod in default namespace?"
  Running: kubectl apply -f - <<EOF
apiVersion: v1
type: Pod
metadata:
  name: my-pod
spec:
  containers:
  - name: my-container
    image: nginx
EOF

  Do you want to proceed ?
  1) Yes
  2) Yes, and don't ask me again
  3) No
  Enter your choice (number): 3

  Operation was skipped. User declined to run this operation.                 



  It seems I wasn't able to create the pod as the operation was declined.     
  However, I can provide you with the YAML definition that you can use to     
  create the pod in the default namespace.                                    
                                                                              
  Here's the YAML manifest for a simple Nginx pod:                            
                                                                              
    apiVersion: v1                                                            
    kind: Pod                                                                 
    metadata:                                                                 
      name: my-pod                                                            
    spec:                                                                     
      containers:                                                             
      - name: my-container                                                    
        image: nginx                                                          
                                                                              
  You can apply this configuration by saving it to a file (e.g.,  pod.yaml )  
  and running:                                                                
                                                                              
    kubectl apply -f pod.yaml                                                 
                                                                              
  Let me know if you need any further assistance! 😊                          


>>> list namespaces
  Running: kubectl get namespaces


  Here are the namespaces in your Kubernetes cluster:                         
                                                                              
  • default: Active                                                           
  • kube-node-lease: Active                                                   
  • kube-public: Active                                                       
  • kube-system: Active                                                       
                                                                              
  If you need more information about any specific namespace or further        
  actions, let me know! 😊                                                    


>>> create a busybox pod in kube system
  Running: kubectl apply -f - <<EOF
apiVersion: v1
type: Pod
metadata:
  name: busybox-pod
  namespace: kube-system
spec:
  containers:
  - name: busybox-container
    image: busybox
    command: ['sh', '-c', 'sleep 3600']
EOF

  Do you want to proceed ?
  1) Yes
  2) Yes, and don't ask me again
  3) No
  Enter your choice (number): 3

  Operation was skipped. User declined to run this operation.                 



  It appears that I am unable to create the BusyBox pod in the  kube-system   
  namespace as the operation was declined.                                    
                                                                              
  You can create the pod using the following YAML manifest:                   
                                                                              
    apiVersion: v1                                                            
    kind: Pod                                                                 
    metadata:                                                                 
      name: busybox-pod                                                       
      namespace: kube-system                                                  
    spec:                                                                     
      containers:                                                             
      - name: busybox-container                                               
        image: busybox                                                        
        command: ['sh', '-c', 'sleep 3600']                                   
                                                                              
  To apply this configuration, save it to a file named  busybox-pod.yaml  and 
  run:                                                                        
                                                                              
    kubectl apply -f busybox-pod.yaml                                         
                                                                              
  If you need any further assistance or have other questions, feel free to    
  ask! 😊                                                                     


>>> create a traefik pod in default namespace
  Running: kubectl apply -f - <<EOF
apiVersion: v1
type: Pod
metadata:
  name: traefik-pod
spec:
  containers:
  - name: traefik-container
    image: traefik:v2.5
    ports:
    - containerPort: 80
    - containerPort: 443
EOF

  Do you want to proceed ?
  1) Yes
  2) Yes, and don't ask me again
  3) No
  Enter your choice (number): 1

  It seems there was an issue with the manifest definition. The  kind  field  
  should be specified correctly. Let's correct that and create the Traefik pod
  again.                                                                      
                                                                              
  I'll retry creating the Traefik pod in the default namespace.               


  Running: kubectl apply -f - <<EOF
apiVersion: v1
kind: Pod
metadata:
  name: traefik-pod
  namespace: default
spec:
  containers:
  - name: traefik-container
    image: traefik:v2.5
    ports:
    - containerPort: 80
    - containerPort: 443
EOF

  Do you want to proceed ?
  1) Yes
  2) Yes, and don't ask me again
  3) No
  Enter your choice (number): 1

  The Traefik pod has been successfully created in the default namespace! 🎉  
                                                                              
  If you have any further requests or need assistance with anything else, just
  let me know!                                                                


>>> list the status of the pod
  Running: kubectl get pod traefik-pod -o jsonpath='{.status.phase}'


  The status of the Traefik pod is Running. 🚀                                
                                                                              
  If you need any more information or have other questions, feel free to ask! 


>>> exit

```


> cc: @droot if you can quick test gemini before merging it would me much appreciated, as i assume this is more specific to openai api, still, returning nil wont break anything if my understanding is correct but as `Context.RunOneRound` is shared, i want to make sure, 
