### PR TITLE
FIX: kubectl streaming and interaction bashtool #122 #232

### DIFF
--- a/pkg/agent/conversation.go
+++ b/pkg/agent/conversation.go
@@ -222,6 +222,11 @@ func (a *Conversation) RunOneRound(ctx context.Context, query string) error {
 		}
 
 		// TODO(droot): Run all function calls in parallel
+		// (may have to specify in the prompt to make these function calls independent)
+		// NOTE: Currently, function calls are executed sequentially.
+		// Suggestion: Use goroutines and sync.WaitGroup to parallelize execution if tool calls are independent.
+		// Be careful with shared state and UI updates if running in parallel.
+
 		for _, call := range functionCalls {
 			toolCall, err := a.Tools.ParseToolInvocation(ctx, call.Name, call.Arguments)
 			if err != nil {
@@ -230,7 +235,7 @@ func (a *Conversation) RunOneRound(ctx context.Context, query string) error {
 
 			// Check if the command is interactive using the tool's implementation
 			isInteractive, errMsg := toolCall.GetTool().IsInteractive(call.Arguments)
-			klog.Infof("isInteractive: %t, errMsg: %s", isInteractive, errMsg)
+			klog.Infof("isInteractive: %t, errMsg: %s, CallArguments: ", isInteractive, errMsg)
 
 			// If interactive, handle based on whether we're using tool-use shim
 			if isInteractive {

--- a/pkg/agent/conversation.go
+++ b/pkg/agent/conversation.go
@@ -209,12 +209,10 @@ func (a *Conversation) RunOneRound(ctx context.Context, query string) error {
 					agentTextBlock.AppendText(text)
 				}
 
-				// Only process function calls if not using tool-use shim
-				if !a.EnableToolUseShim {
-					if calls, ok := part.AsFunctionCalls(); ok && len(calls) > 0 {
-						log.Info("function calls", "calls", calls)
-						functionCalls = append(functionCalls, calls...)
-					}
+				// Check if it's a function call
+				if calls, ok := part.AsFunctionCalls(); ok && len(calls) > 0 {
+					log.Info("function calls", "calls", calls)
+					functionCalls = append(functionCalls, calls...)
 				}
 			}
 		}
@@ -223,115 +221,115 @@ func (a *Conversation) RunOneRound(ctx context.Context, query string) error {
 			agentTextBlock.SetStreaming(false)
 		}
 
-		// Only process function calls if not using tool-use shim
-		if !a.EnableToolUseShim {
-			// TODO(droot): Run all function calls in parallel
-			for _, call := range functionCalls {
-				toolCall, err := a.Tools.ParseToolInvocation(ctx, call.Name, call.Arguments)
-				if err != nil {
-					return fmt.Errorf("building tool call: %w", err)
-				}
+		// TODO(droot): Run all function calls in parallel
+		for _, call := range functionCalls {
+			toolCall, err := a.Tools.ParseToolInvocation(ctx, call.Name, call.Arguments)
+			if err != nil {
+				return fmt.Errorf("building tool call: %w", err)
+			}
 
-				// Check if the command is interactive using the tool's implementation
-				isInteractive, errMsg := toolCall.GetTool().IsInteractive(call.Arguments)
-				klog.Infof("isInteractive: %t, errMsg: %s", isInteractive, errMsg)
+			// Check if the command is interactive using the tool's implementation
+			isInteractive, errMsg := toolCall.GetTool().IsInteractive(call.Arguments)
+			klog.Infof("isInteractive: %t, errMsg: %s", isInteractive, errMsg)
 
-				// If interactive, handle based on whether we're using tool-use shim
-				if isInteractive {
-					if a.EnableToolUseShim {
-						// For models without tool-use support, append as text response
-						if agentTextBlock == nil {
-							agentTextBlock = ui.NewAgentTextBlock()
-							a.doc.AddBlock(agentTextBlock)
-						}
-						agentTextBlock.AppendText(fmt.Sprintf("  %s\n", errMsg))
-					} else {
-						// For models with tool-use support, use proper FunctionCallResult
-						errorBlock := ui.NewErrorBlock().SetText(fmt.Sprintf("  %s\n", errMsg))
-						a.doc.AddBlock(errorBlock)
-
-						currChatContent = append(currChatContent, gollm.FunctionCallResult{
-							ID:     call.ID,
-							Name:   call.Name,
-							Result: map[string]any{"error": errMsg},
-						})
+			// If interactive, handle based on whether we're using tool-use shim
+			if isInteractive {
+				if a.EnableToolUseShim {
+					// For models without tool-use support (shim enabled), append as text response
+					if agentTextBlock == nil {
+						agentTextBlock = ui.NewAgentTextBlock()
+						a.doc.AddBlock(agentTextBlock)
 					}
-					continue
+					agentTextBlock.AppendText(fmt.Sprintf("  %s\n", errMsg))
+				} else {
+					// For models with tool-use support (shim disabled), use proper FunctionCallResult
+					errorBlock := ui.NewErrorBlock().SetText(fmt.Sprintf("  %s\n", errMsg))
+					a.doc.AddBlock(errorBlock)
+
+					// Note: This assumes the model supports sending FunctionCallResult
+					currChatContent = append(currChatContent, gollm.FunctionCallResult{
+						ID:     call.ID,
+						Name:   call.Name,
+						Result: map[string]any{"error": errMsg},
+					})
 				}
+				continue // Skip execution for interactive commands
+			}
 
-				// Only show "Running" message and proceed with execution for non-interactive commands
-				s := toolCall.PrettyPrint()
-				a.doc.AddBlock(ui.NewFunctionCallRequestBlock().SetText(fmt.Sprintf("  Running: %s\n", s)))
+			// Only show "Running" message and proceed with execution for non-interactive commands
+			s := toolCall.PrettyPrint()
+			a.doc.AddBlock(ui.NewFunctionCallRequestBlock().SetText(fmt.Sprintf("  Running: %s\n", s)))
 
-				var result any
-				var invokeErr error
-
-				// Execute the command
-				result, invokeErr = toolCall.InvokeTool(ctx, tools.InvokeToolOptions{
-					Kubeconfig: a.Kubeconfig,
-					WorkDir:    a.workDir,
-				})
-				if invokeErr != nil {
-					return fmt.Errorf("executing action: %w", invokeErr)
-				}
-
-				// Convert result to map for the LLM
-				resultMap, err := tools.ToolResultToMap(result)
-				if err != nil {
-					return err
-				}
-
-				// Handle timeout message using UI blocks
-				if execResult, ok := result.(*tools.ExecResult); ok && execResult.StreamType == "timeout" {
-					a.doc.AddBlock(ui.NewAgentTextBlock().WithText("\nTimeout reached after 7 seconds\n"))
-				}
-
-				// Add the tool call result to maintain conversation flow
-				currChatContent = append(currChatContent, gollm.FunctionCallResult{
-					ID:     call.ID,
-					Name:   call.Name,
-					Result: resultMap,
-				})
-
-				// Only ask for confirmation if SkipPermissions is false and command modifies a resource
-				if !a.SkipPermissions && call.Arguments["modifies_resource"] != "no" {
-					confirmationPrompt := `  Do you want to proceed ?
+			// Ask for confirmation only if SkipPermissions is false AND the tool modifies resources.
+			if !a.SkipPermissions && call.Arguments["modifies_resource"] != "no" {
+				confirmationPrompt := `  Do you want to proceed ?
   1) Yes
   2) Yes, and don't ask me again
   3) No`
 
-					optionsBlock := ui.NewInputOptionBlock().SetPrompt(confirmationPrompt)
-					optionsBlock.SetOptions([]string{"1", "2", "3"})
-					a.doc.AddBlock(optionsBlock)
+				optionsBlock := ui.NewInputOptionBlock().SetPrompt(confirmationPrompt)
+				optionsBlock.SetOptions([]string{"1", "2", "3"})
+				a.doc.AddBlock(optionsBlock)
 
-					selectedChoice, err := optionsBlock.Observable().Wait()
-					if err != nil {
-						if err == io.EOF {
-							// Use hit control-D, or was piping and we reached the end of stdin.
-							// Not a "big" problem
-							return nil
-						}
-						return fmt.Errorf("reading input: %w", err)
+				selectedChoice, err := optionsBlock.Observable().Wait()
+				if err != nil {
+					if err == io.EOF {
+						return nil
 					}
-
-					switch selectedChoice {
-					case "1":
-						// Proceed with the operation
-					case "2":
-						a.SkipPermissions = true
-					case "3":
-						a.doc.AddBlock(ui.NewAgentTextBlock().WithText("Operation was skipped."))
-						observation := fmt.Sprintf("User didn't approve running %q.\n", call.Name)
-						currChatContent = append(currChatContent, observation)
-						continue
-					default:
-						// This case should technically not be reachable due to AskForConfirmation loop
-						err := fmt.Errorf("invalid confirmation choice: %q", selectedChoice)
-						log.Error(err, "Invalid choice received from AskForConfirmation")
-						a.doc.AddBlock(ui.NewErrorBlock().SetText("Invalid choice received. Cancelling operation."))
-						return err
-					}
+					return fmt.Errorf("reading input: %w", err)
 				}
+
+				switch selectedChoice {
+				case "1":
+					// Proceed with the operation
+				case "2":
+					a.SkipPermissions = true
+				case "3":
+					a.doc.AddBlock(ui.NewAgentTextBlock().WithText("Operation was skipped."))
+					observation := fmt.Sprintf("User didn't approve running %q.\n", call.Name)
+					// Add the observation back to the chat content
+					currChatContent = append(currChatContent, observation)
+					continue // Skip execution and move to the next function call
+				default:
+					// This case should technically not be reachable due to AskForConfirmation loop
+					err := fmt.Errorf("invalid confirmation choice: %q", selectedChoice)
+					log.Error(err, "Invalid choice received from AskForConfirmation")
+					a.doc.AddBlock(ui.NewErrorBlock().SetText("Invalid choice received. Cancelling operation."))
+					return err
+				}
+			}
+
+			ctx := journal.ContextWithRecorder(ctx, a.Recorder)
+			output, err := toolCall.InvokeTool(ctx, tools.InvokeToolOptions{
+				Kubeconfig: a.Kubeconfig,
+				WorkDir:    a.workDir,
+			})
+			if err != nil {
+				return fmt.Errorf("executing action: %w", err)
+			}
+
+			// Handle timeout message using UI blocks
+			if execResult, ok := output.(*tools.ExecResult); ok && execResult.StreamType == "timeout" {
+				a.doc.AddBlock(ui.NewAgentTextBlock().WithText("\nTimeout reached after 7 seconds\n"))
+			}
+
+			// Add the tool call result to maintain conversation flow
+			if a.EnableToolUseShim {
+				// If shim is enabled, format the result as a text observation
+				observation := fmt.Sprintf("Result of running %q:\n%s", call.Name, output)
+				currChatContent = append(currChatContent, observation)
+			} else {
+				// If shim is disabled, convert the result to a map and append FunctionCallResult
+				result, err := tools.ToolResultToMap(output)
+				if err != nil {
+					return err
+				}
+
+				currChatContent = append(currChatContent, gollm.FunctionCallResult{
+					ID:     call.ID,
+					Name:   call.Name,
+					Result: result,
+				})
 			}
 		}
 

--- a/pkg/agent/conversation.go
+++ b/pkg/agent/conversation.go
@@ -230,15 +230,9 @@ func (a *Conversation) RunOneRound(ctx context.Context, query string) error {
 				return fmt.Errorf("building tool call: %w", err)
 			}
 
-			// Check if this is a kubectl or bash command that might be interactive
-			isInteractive := false
-			var errMsg string
-			if call.Name == "kubectl" || call.Name == "bash" {
-				if command, ok := call.Arguments["command"].(string); ok {
-					isInteractive, errMsg = tools.IsInteractiveCommand(command)
-				}
-			}
-
+			// Check if the command is interactive using the tool's implementation
+			isInteractive, errMsg := toolCall.GetTool().IsInteractive(call.Arguments)
+			klog.Infof("isInteractive: %t, errMsg: %s", isInteractive, errMsg)
 			// If interactive, show error and skip to next iteration
 			if isInteractive {
 				// Use ErrorBlock for interactive command errors

--- a/pkg/agent/conversation.go
+++ b/pkg/agent/conversation.go
@@ -235,7 +235,7 @@ func (a *Conversation) RunOneRound(ctx context.Context, query string) error {
 
 			// Check if the command is interactive using the tool's implementation
 			isInteractive, errMsg := toolCall.GetTool().IsInteractive(call.Arguments)
-			klog.Infof("isInteractive: %t, errMsg: %s, CallArguments: ", isInteractive, errMsg)
+			klog.Infof("isInteractive: %t, errMsg: %s, CallArguments: %+v", isInteractive, errMsg, call.Arguments)
 
 			// If interactive, handle based on whether we're using tool-use shim
 			if isInteractive {

--- a/pkg/tools/bash_tool.go
+++ b/pkg/tools/bash_tool.go
@@ -144,9 +144,10 @@ func executeCommand(cmd *exec.Cmd) (*ExecResult, error) {
 	isExec := strings.Contains(command, "kubectl exec") && strings.Contains(command, "-it")
 	isAttach := strings.Contains(command, "kubectl attach")
 	isPortForward := strings.Contains(command, "kubectl port-forward")
+	isEdit := strings.Contains(command, "kubectl edit")
 
 	// Block interactive commands
-	if isExec || isPortForward {
+	if isExec || isPortForward || isEdit {
 		return &ExecResult{Error: "interactive mode not supported for kubectl, please use non-interactive commands"}, nil
 	}
 

--- a/pkg/tools/bash_tool.go
+++ b/pkg/tools/bash_tool.go
@@ -280,3 +280,17 @@ func executeCommand(cmd *exec.Cmd) (*ExecResult, error) {
 	results.Stderr = stderr.String()
 	return results, nil
 }
+
+func (t *BashTool) IsInteractive(args map[string]any) (bool, string) {
+	commandVal, ok := args["command"]
+	if !ok || commandVal == nil {
+		return false, ""
+	}
+
+	command, ok := commandVal.(string)
+	if !ok {
+		return false, ""
+	}
+
+	return IsInteractiveCommand(command)
+}

--- a/pkg/tools/custom_tool.go
+++ b/pkg/tools/custom_tool.go
@@ -26,10 +26,11 @@ import (
 
 // CustomToolConfig defines the structure for configuring a custom tool.
 type CustomToolConfig struct {
-	Name        string `yaml:"name"`
-	Description string `yaml:"description"`
-	Command     string `yaml:"command"`
-	CommandDesc string `yaml:"command_desc"`
+	Name          string `yaml:"name"`
+	Description   string `yaml:"description"`
+	Command       string `yaml:"command"`
+	CommandDesc   string `yaml:"command_desc"`
+	IsInteractive bool   `yaml:"is_interactive"`
 }
 
 // CustomTool implements the Tool interface for external commands.

--- a/pkg/tools/interfaces.go
+++ b/pkg/tools/interfaces.go
@@ -38,5 +38,6 @@ type Tool interface {
 
 	// IsInteractive checks if a command is interactive
 	// If the command is interactive, we need to handle it differently in the agent
-	IsInteractive(args map[string]any) (bool, string)
+	// Returns true if interactive, with an error explaining why it's interactive
+	IsInteractive(args map[string]any) (bool, error)
 }

--- a/pkg/tools/interfaces.go
+++ b/pkg/tools/interfaces.go
@@ -37,5 +37,6 @@ type Tool interface {
 	Run(ctx context.Context, args map[string]any) (any, error)
 
 	// IsInteractive checks if a command is interactive
+	// If the command is interactive, we need to handle it differently in the agent
 	IsInteractive(args map[string]any) (bool, string)
 }

--- a/pkg/tools/interfaces.go
+++ b/pkg/tools/interfaces.go
@@ -35,4 +35,7 @@ type Tool interface {
 
 	// Run invokes the tool, the agent calls this when the LLM requests tool invocation.
 	Run(ctx context.Context, args map[string]any) (any, error)
+
+	// IsInteractive checks if a command is interactive
+	IsInteractive(args map[string]any) (bool, string)
 }

--- a/pkg/tools/kubectl_tool.go
+++ b/pkg/tools/kubectl_tool.go
@@ -88,6 +88,11 @@ func (t *Kubectl) Run(ctx context.Context, args map[string]any) (any, error) {
 }
 
 func runKubectlCommand(ctx context.Context, command, workDir, kubeconfig string) (*ExecResult, error) {
+	// Check for interactive commands before proceeding
+	if isInteractive, errMsg := IsInteractiveCommand(command); isInteractive {
+		return &ExecResult{Error: errMsg}, nil
+	}
+
 	var cmd *exec.Cmd
 	if runtime.GOOS == "windows" {
 		cmd = exec.CommandContext(ctx, os.Getenv("COMSPEC"), "/c", command)

--- a/pkg/tools/kubectl_tool.go
+++ b/pkg/tools/kubectl_tool.go
@@ -38,11 +38,11 @@ func (t *Kubectl) Description() string {
 
 IMPORTANT: Interactive commands are not supported in this environment. This includes:
 - kubectl exec with -it flag (use non-interactive exec instead)
-- kubectl edit (use kubectl get -o yaml and kubectl apply instead)
+- kubectl edit (use kubectl get -o yaml, kubectl patch, or kubectl apply instead)
 - kubectl port-forward (use alternative methods like NodePort or LoadBalancer)
 
 For interactive operations, please use these non-interactive alternatives:
-- Instead of 'kubectl edit', use 'kubectl get -o yaml' to view and 'kubectl apply' to apply changes
+- Instead of 'kubectl edit', use 'kubectl get -o yaml' to view, 'kubectl patch' for targeted changes, or 'kubectl apply' to apply full changes
 - Instead of 'kubectl exec -it', use 'kubectl exec' with a specific command
 - Instead of 'kubectl port-forward', use service types like NodePort or LoadBalancer`
 }
@@ -59,7 +59,7 @@ func (t *Kubectl) FunctionDefinition() *gollm.FunctionDefinition {
 					Description: `The complete kubectl command to execute. Prefer to use heredoc syntax for multi-line commands. Please include the kubectl prefix as well.
 
 IMPORTANT: Do not use interactive commands. Instead:
-- Use 'kubectl get -o yaml' and 'kubectl apply' instead of 'kubectl edit'
+- Use 'kubectl get -o yaml', 'kubectl patch', or 'kubectl apply' instead of 'kubectl edit'
 - Use 'kubectl exec' with specific commands instead of 'kubectl exec -it'
 - Use service types like NodePort or LoadBalancer instead of 'kubectl port-forward'
 
@@ -71,7 +71,11 @@ user: what is the status of the pod my-pod?
 assistant: kubectl get pod my-pod -o jsonpath='{.status.phase}'
 
 user: I need to edit the pod configuration
-assistant: kubectl get pod my-pod -o yaml > pod.yaml
+assistant: # Option 1: Using patch for targeted changes
+kubectl patch pod my-pod --patch '{"spec":{"containers":[{"name":"main","image":"new-image"}]}}'
+
+# Option 2: Using get and apply for full changes
+kubectl get pod my-pod -o yaml > pod.yaml
 # Edit pod.yaml locally
 kubectl apply -f pod.yaml
 

--- a/pkg/tools/kubectl_tool.go
+++ b/pkg/tools/kubectl_tool.go
@@ -138,3 +138,17 @@ func runKubectlCommand(ctx context.Context, command, workDir, kubeconfig string)
 
 	return executeCommand(cmd)
 }
+
+func (t *Kubectl) IsInteractive(args map[string]any) (bool, string) {
+	commandVal, ok := args["command"]
+	if !ok || commandVal == nil {
+		return false, ""
+	}
+
+	command, ok := commandVal.(string)
+	if !ok {
+		return false, ""
+	}
+
+	return IsInteractiveCommand(command)
+}

--- a/pkg/tools/kubectl_tool.go
+++ b/pkg/tools/kubectl_tool.go
@@ -19,7 +19,6 @@ import (
 	"os"
 	"os/exec"
 	"runtime"
-	"strings"
 
 	"github.com/GoogleCloudPlatform/kubectl-ai/gollm"
 )
@@ -89,13 +88,6 @@ func (t *Kubectl) Run(ctx context.Context, args map[string]any) (any, error) {
 }
 
 func runKubectlCommand(ctx context.Context, command, workDir, kubeconfig string) (*ExecResult, error) {
-	if strings.Contains(command, "kubectl edit") {
-		return &ExecResult{Error: "interactive mode not supported for kubectl, please use non-interactive commands"}, nil
-	}
-	if strings.Contains(command, "kubectl port-forward") {
-		return &ExecResult{Error: "port-forwarding is not allowed because assistant is running in an unattended mode, please try some other alternative"}, nil
-	}
-
 	var cmd *exec.Cmd
 	if runtime.GOOS == "windows" {
 		cmd = exec.CommandContext(ctx, os.Getenv("COMSPEC"), "/c", command)

--- a/pkg/tools/kubectl_tool.go
+++ b/pkg/tools/kubectl_tool.go
@@ -116,8 +116,8 @@ func (t *Kubectl) Run(ctx context.Context, args map[string]any) (any, error) {
 
 func runKubectlCommand(ctx context.Context, command, workDir, kubeconfig string) (*ExecResult, error) {
 	// Check for interactive commands before proceeding
-	if isInteractive, errMsg := IsInteractiveCommand(command); isInteractive {
-		return &ExecResult{Error: errMsg}, nil
+	if isInteractive, err := IsInteractiveCommand(command); isInteractive {
+		return &ExecResult{Error: err.Error()}, nil
 	}
 
 	var cmd *exec.Cmd
@@ -139,15 +139,15 @@ func runKubectlCommand(ctx context.Context, command, workDir, kubeconfig string)
 	return executeCommand(cmd)
 }
 
-func (t *Kubectl) IsInteractive(args map[string]any) (bool, string) {
+func (t *Kubectl) IsInteractive(args map[string]any) (bool, error) {
 	commandVal, ok := args["command"]
 	if !ok || commandVal == nil {
-		return false, ""
+		return false, nil
 	}
 
 	command, ok := commandVal.(string)
 	if !ok {
-		return false, ""
+		return false, nil
 	}
 
 	return IsInteractiveCommand(command)

--- a/pkg/tools/kubectl_tool.go
+++ b/pkg/tools/kubectl_tool.go
@@ -34,7 +34,17 @@ func (t *Kubectl) Name() string {
 }
 
 func (t *Kubectl) Description() string {
-	return "Executes a kubectl command against the user's Kubernetes cluster. Use this tool only when you need to query or modify the state of the user's Kubernetes cluster."
+	return `Executes a kubectl command against the user's Kubernetes cluster. Use this tool only when you need to query or modify the state of the user's Kubernetes cluster.
+
+IMPORTANT: Interactive commands are not supported in this environment. This includes:
+- kubectl exec with -it flag (use non-interactive exec instead)
+- kubectl edit (use kubectl get -o yaml and kubectl apply instead)
+- kubectl port-forward (use alternative methods like NodePort or LoadBalancer)
+
+For interactive operations, please use these non-interactive alternatives:
+- Instead of 'kubectl edit', use 'kubectl get -o yaml' to view and 'kubectl apply' to apply changes
+- Instead of 'kubectl exec -it', use 'kubectl exec' with a specific command
+- Instead of 'kubectl port-forward', use service types like NodePort or LoadBalancer`
 }
 
 func (t *Kubectl) FunctionDefinition() *gollm.FunctionDefinition {
@@ -47,13 +57,26 @@ func (t *Kubectl) FunctionDefinition() *gollm.FunctionDefinition {
 				"command": {
 					Type: gollm.TypeString,
 					Description: `The complete kubectl command to execute. Prefer to use heredoc syntax for multi-line commands. Please include the kubectl prefix as well.
-Example:
+
+IMPORTANT: Do not use interactive commands. Instead:
+- Use 'kubectl get -o yaml' and 'kubectl apply' instead of 'kubectl edit'
+- Use 'kubectl exec' with specific commands instead of 'kubectl exec -it'
+- Use service types like NodePort or LoadBalancer instead of 'kubectl port-forward'
+
+Examples:
 user: what pods are running in the cluster?
 assistant: kubectl get pods
 
 user: what is the status of the pod my-pod?
 assistant: kubectl get pod my-pod -o jsonpath='{.status.phase}'
-`,
+
+user: I need to edit the pod configuration
+assistant: kubectl get pod my-pod -o yaml > pod.yaml
+# Edit pod.yaml locally
+kubectl apply -f pod.yaml
+
+user: I need to execute a command in the pod
+assistant: kubectl exec my-pod -- /bin/sh -c "your command here"`,
 				},
 				"modifies_resource": {
 					Type: gollm.TypeString,

--- a/pkg/tools/tools.go
+++ b/pkg/tools/tools.go
@@ -245,9 +245,9 @@ func LoadAndRegisterCustomTools(configPath string) error {
 }
 
 // For CustomTool
-func (t *CustomTool) IsInteractive(args map[string]any) (bool, string) {
+func (t *CustomTool) IsInteractive(args map[string]any) (bool, error) {
 	// Custom tools are not interactive by default
-	return false, ""
+	return false, nil
 }
 
 // Add a method to access the tool

--- a/pkg/tools/tools.go
+++ b/pkg/tools/tools.go
@@ -243,3 +243,14 @@ func LoadAndRegisterCustomTools(configPath string) error {
 
 	return nil
 }
+
+// For CustomTool
+func (t *CustomTool) IsInteractive(args map[string]any) (bool, string) {
+	// Custom tools are not interactive by default
+	return false, ""
+}
+
+// Add a method to access the tool
+func (t *ToolCall) GetTool() Tool {
+	return t.tool
+}

--- a/pkg/tools/trivy_tool.go
+++ b/pkg/tools/trivy_tool.go
@@ -88,7 +88,7 @@ func parseFunctionArgs(functionArgs map[string]any, task any) error {
 	return nil
 }
 
-func (t *ScanImageWithTrivy) IsInteractive(args map[string]any) (bool, string) {
+func (t *ScanImageWithTrivy) IsInteractive(args map[string]any) (bool, error) {
 	// Trivy scan operations are not interactive
-	return false, ""
+	return false, nil
 }

--- a/pkg/tools/trivy_tool.go
+++ b/pkg/tools/trivy_tool.go
@@ -87,3 +87,8 @@ func parseFunctionArgs(functionArgs map[string]any, task any) error {
 	}
 	return nil
 }
+
+func (t *ScanImageWithTrivy) IsInteractive(args map[string]any) (bool, string) {
+	// Trivy scan operations are not interactive
+	return false, ""
+}


### PR DESCRIPTION
# Fix streaming command handling with timeout

## Summary
Implements a simple timeout-based approach for handling streaming kubectl commands. It addresses issues with commands like `kubectl logs -f` and `kubectl get -w` by automatically terminating them after 7 seconds, while still allowing users to see the output in real-time.

## Changes
- Added detection for various streaming kubectl commands:
  - `kubectl logs -f`
  - `kubectl get -w`
  - `kubectl attach`
- Explicitly blocked interactive commands:
  - `kubectl exec -it`
  - `kubectl port-forward`
- Implemented a 7-second timeout for all streaming commands
- Added proper stream type identification for different operations
- Simplified the command execution logic by removing complex input handling

## Testing
```
>>> ^C
❯ ./kubectl-ai --llm-provider=openai --model=claude-3-5-sonnet-20241022 "create a pod in the default namespace that outputs to stdout a random 6char string every 4 secs"

  I'll help you create a pod that generates and outputs random 6-character    
  strings every 4 seconds. I'll use a shell script with  tr  and  head        
  commands to generate random strings, running in a container.                
                                                                              
  Let me create this pod using  kubectl :                                     


  Running: cat << 'EOF' | kubectl apply -f -
apiVersion: v1
kind: Pod
metadata:
  name: random-string-generator
  namespace: default
spec:
  containers:
  - name: random-generator
    image: busybox:latest
    command: ["/bin/sh", "-c"]
    args:
      - while true; do
          head -c 32 /dev/urandom | tr -dc 'a-zA-Z0-9' | head -c 6;
          echo;
          sleep 4;
        done
EOF

  Do you want to proceed ?
  1) Yes
  2) Yes, and don't ask me again
  3) No
  Enter your choice (number): 1

  Great! I've created a pod with the following characteristics:               
                                                                              
  1. Name: random-string-generator                                            
  2. Uses busybox image (lightweight and contains necessary tools)            
  3. Runs a shell script that:                                                
    • Reads random data from /dev/urandom                                     
    • Filters it to only alphanumeric characters                              
    • Takes 6 characters                                                      
    • Outputs the string                                                      
    • Sleeps for 4 seconds                                                    
    • Repeats indefinitely                                                    
                                                                              
                                                                              
  Let's verify that the pod is running and check its logs to see the output:  


  Running: kubectl get pod random-string-generator


  Let's see the output:                                                       


  Running: kubectl logs -f random-string-generator --tail=5
laXnwl
2z8vyP
TO0dk

Timeout reached after 7 seconds


  Perfect! 🎉 The pod is running successfully and generating random 6-        
  character                                                                   
  strings every 4 seconds. You can continue to monitor the output using:      
                                                                              
    kubectl logs -f random-string-generator                                   
                                                                              
  The pod will continue running and generating random strings until it's      
  deleted. Would you like me to show you more output or help you with anything
  else?                                                                       

```

```
❯ ./kubectl-ai --llm-provider=openai --model=claude-3-5-sonnet-20241022 "can we exec into random-string-generator pod in default?"

  I'll help you exec into the random-string-generator pod. Let me first verify
  the pod exists and is running.                                              


  Running: kubectl get pod random-string-generator -n default


  Great! The pod exists and is running. Let me execute into the pod. I'll use 
  the default container since there appears to be only one container (READY   
  1/1).                                                                       


  Running: kubectl exec -it random-string-generator -n default -- sh


  I apologize for the confusion. It seems the interactive terminal session is 
  not supported through this interface. However, I can help you run specific  
  commands within the pod if you'd like. For example, I could:                
                                                                              
  1. List the contents of a directory                                         
  2. Check environment variables                                              
  3. Run a specific command                                                   
  4. View running processes                                                   
  5. Check the application logs                                               
                                                                              
  Would you like me to run any specific command inside the pod? Please let me 
  know what you'd like to do within the container, and I'll help you execute  
  that command non-interactively.                                             

```

## Related Issues
Closes #122 - Need to print outputs of commands that run in a loop
Closes #232 - Ability to gracefully exit from streaming commands

## Notes
- Tried using Control+C but the repl and signals we're giving me implementation issues,
- 7 is an arbitrary number, i had the idea to make it interactive to, so prompt user to add a timeout, but perhaps someone wants to run kubectl-ai automatically or dokcerized as mentioned in some feature requests
- I also had an idea to add a global flag to it, so the timeout being 7 and allowing it to be customize it

I'm open to modifications maybe a mix of the two?
![image](https://github.com/user-attachments/assets/65b2d607-d9d1-4ea6-a297-d6259a3c566f)
