### PR TITLE
fix: improve stdin data detection logic in debug mode

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -575,15 +575,24 @@ func (writer klogWriter) Write(data []byte) (n int, err error) {
 }
 
 func hasStdInData() (bool, error) {
-	hasData := false
-
 	stat, err := os.Stdin.Stat()
 	if err != nil {
-		return hasData, fmt.Errorf("checking stdin: %w", err)
+		return false, fmt.Errorf("checking stdin: %w", err)
 	}
-	hasData = (stat.Mode() & os.ModeCharDevice) == 0
 
-	return hasData, nil
+	// If stdin is a character device (terminal), there's no piped data
+	if (stat.Mode() & os.ModeCharDevice) != 0 {
+		return false, nil
+	}
+
+	// For non-character devices, check if there's actually data available
+	// This handles cases like VS Code debugger where stdin might be redirected
+	// but there's no actual data
+	if stat.Size() == 0 {
+		return false, nil
+	}
+
+	return true, nil
 }
 
 // resolveQueryInput determines the query input from positional args and/or stdin.


### PR DESCRIPTION
This pull request refines the `hasStdInData` function in `cmd/main.go` to improve its handling of standard input (stdin) data detection. 

When someone us running the program in debug mode hasData returns `true` while there is no data.  The reason is that vscode attaches io to the process.  As a result the process hangs using these debug settings (as an example)

```
{
    // Use IntelliSense to learn about possible attributes.
    // Hover to view descriptions of existing attributes.
    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
    "version": "0.2.0",
    "configurations": [
        {
            "name": "attach",
            "type": "go",
            "request": "attach",
            "mode": "local",
            "processId": 0
        },
        {
            "name": "html ui",
            "type": "go",
            "request": "launch",
            "mode": "debug",
            "program": "${workspaceFolder}/cmd",
            "args": ["--user-interface", "html"],
            "envFile": "${workspaceFolder}/.env",
        },
        {
            "name": "cli",
            "type": "go",
            "request": "launch",
            "mode": "debug",
            "program": "${workspaceFolder}/cmd",
            "envFile": "${workspaceFolder}/.env",
        }
    ]
}
```