### PR TITLE
fix: Improve CLI prompt and input handling for confirmation choices

### DIFF
--- a/pkg/agent/conversation.go
+++ b/pkg/agent/conversation.go
@@ -240,7 +240,7 @@ func (a *Conversation) RunOneRound(ctx context.Context, query string) error {
   3) No`
 
 				optionsBlock := ui.NewInputOptionBlock().SetPrompt(confirmationPrompt)
-				optionsBlock.SetOptions([]string{"1", "2", "3"})
+				optionsBlock.SetOptions([]string{"1", "2", "3", "yes", "y", "no", "n"})
 				a.doc.AddBlock(optionsBlock)
 
 				selectedChoice, err := optionsBlock.Observable().Wait()
@@ -253,12 +253,14 @@ func (a *Conversation) RunOneRound(ctx context.Context, query string) error {
 					return fmt.Errorf("reading input: %w", err)
 				}
 
+				// Normalize the input
+				selectedChoice = strings.ToLower(strings.TrimSpace(selectedChoice))
 				switch selectedChoice {
-				case "1":
+				case "1", "yes", "y":
 					// Proceed with the operation
 				case "2":
 					a.SkipPermissions = true
-				case "3":
+				case "3", "no", "n":
 					a.doc.AddBlock(ui.NewAgentTextBlock().WithText("Operation was skipped. User declined to run this operation."))
 					currChatContent = append(currChatContent, gollm.FunctionCallResult{
 						ID:   call.ID,

--- a/pkg/ui/terminal.go
+++ b/pkg/ui/terminal.go
@@ -219,7 +219,7 @@ func (u *TerminalUI) DocumentChanged(doc *Document, block Block) {
 				return
 			}
 			for {
-				fmt.Print("  Enter your choice (number): ") // Print loop prompt manually
+				fmt.Print("  Enter your choice (1,2,3): ") // Print loop prompt manually
 				response, err := tReader.ReadString('\n')
 				if err != nil {
 					block.Observable().Set("", err)
@@ -240,7 +240,7 @@ func (u *TerminalUI) DocumentChanged(doc *Document, block Block) {
 			}
 			// Temporarily change prompt for option selection
 			originalPrompt := rlInstance.Config.Prompt
-			choicePrompt := "  Enter your choice (number): "
+			choicePrompt := "  Enter your choice (1,2,3): "
 			rlInstance.SetPrompt(choicePrompt)
 			// Ensure original prompt is restored even if errors occur
 			defer rlInstance.SetPrompt(originalPrompt)


### PR DESCRIPTION
### Summary

This PR enhances https://github.com/GoogleCloudPlatform/kubectl-ai/issues/275 & improves the user experience of confirmation prompts in the CLI by:

- Making the prompt more intuitive and informative
- Supporting natural language inputs like "yes", "no", "y", and "n" in addition to numeric options


Here are some screenshot's -
<img width="649" alt="Screenshot 2025-05-25 at 12 22 51 AM" src="https://github.com/user-attachments/assets/39268d7c-f71c-4c80-8258-a43b1dcccf03" />
<img width="606" alt="Screenshot 2025-05-25 at 12 26 26 AM" src="https://github.com/user-attachments/assets/7b16d0c3-63fb-4332-9478-58d3f7b34215" />
