### PR TITLE
Fix: make config.yaml Optional 

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -198,9 +198,8 @@ func (o *Options) LoadConfigurationFile() error {
 		configPath = filepath.Clean(pathWithPlaceholdersExpanded)
 		configBytes, err := os.ReadFile(configPath)
 		if err != nil {
-			if os.IsNotExist(err) && !slices.Contains(defaultConfigPaths, configPath) {
-				// user specified config file does not exist
-				return fmt.Errorf("could not load config from %q: %w", configPath, err)
+			if os.IsNotExist(err) {
+				// ignore missing config files, they are optional
 			} else {
 				fmt.Fprintf(os.Stderr, "warning: could not load defaults from %q: %v\n", configPath, err)
 			}


### PR DESCRIPTION
Fix: #280

After the https://github.com/GoogleCloudPlatform/kubectl-ai/pull/271  change,
If there is no `config.yaml` file in the environment, kubectl-ai will fail to run.

```
root@gpu3090:~/oss/kubectl-ai# task run
task: [run] go run ./cmd
failed to load config file: could not load config from "/root/.config/kubectl-ai/config.yaml": open /root/.config/kubectl-ai/config.yaml: no such file or directory
exit status 1
task: Failed to run task "run": exit status 1
```


This behavior is unexpected, so we should revert this part of the code to its previous state,
making it ​​ignore missing config files​​ (i.e., treat them as ​​optional​​).

----
kubectl-ai version: main branch 