### PR TITLE
feat(cli): Adding a Description to UserInterface in the CLI

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -289,7 +289,7 @@ func (opt *Options) bindCLIFlags(f *pflag.FlagSet) error {
 	f.BoolVar(&opt.EnableToolUseShim, "enable-tool-use-shim", opt.EnableToolUseShim, "enable tool use shim")
 	f.BoolVar(&opt.Quiet, "quiet", opt.Quiet, "run in non-interactive mode, requires a query to be provided as a positional argument")
 
-	f.Var(&opt.UserInterface, "user-interface", "user interface mode to use")
+	f.Var(&opt.UserInterface, "user-interface", "user interface mode to use. Supported values: terminal, html.")
 	f.BoolVar(&opt.SkipVerifySSL, "skip-verify-ssl", opt.SkipVerifySSL, "skip verifying the SSL certificate of the LLM provider")
 
 	return nil


### PR DESCRIPTION
Add a description for UserInterface In the CLI, "User interface mode to use. Supported values: terminal, html."

Because currently there is no documentation for the usage of `html`, it can only be seen by referring to the code.