### PR TITLE
Revert "fix: improve stdin data detection logic in debug mode"

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -595,24 +595,15 @@ func (writer klogWriter) Write(data []byte) (n int, err error) {
 }
 
 func hasStdInData() (bool, error) {
+	hasData := false
+
 	stat, err := os.Stdin.Stat()
 	if err != nil {
-		return false, fmt.Errorf("checking stdin: %w", err)
+		return hasData, fmt.Errorf("checking stdin: %w", err)
 	}
+	hasData = (stat.Mode() & os.ModeCharDevice) == 0
 
-	// If stdin is a character device (terminal), there's no piped data
-	if (stat.Mode() & os.ModeCharDevice) != 0 {
-		return false, nil
-	}
-
-	// For non-character devices, check if there's actually data available
-	// This handles cases like VS Code debugger where stdin might be redirected
-	// but there's no actual data
-	if stat.Size() == 0 {
-		return false, nil
-	}
-
-	return true, nil
+	return hasData, nil
 }
 
 // resolveQueryInput determines the query input from positional args and/or stdin.


### PR DESCRIPTION
Reverts GoogleCloudPlatform/kubectl-ai#277

We discovered our periodic evals were failing.

```sh
KUBECONFIG=~/.kube/auto-ai-1 TEST_ARGS="--enable-tool-use-shim=false --models gemini-2.5-flash-preview-04-17 --task-pattern scale-down" ./dev/ci/periodics/run-evals.sh
...
...
Auto-configuring concurrency to 1 (number of tasks)
Running tasks with concurrency: 1
Worker 0: Evaluating task: scale-down-deployment

Running command: /usr/local/google/home/sunilarora/work/kubectl-ai/k8s-bench/tasks/scale-down-deployment/setup.sh
namespace/scale-down-test created
Warning: autopilot-default-resources-mutator:Autopilot updated Deployment scale-down-test/web-service: defaulted unspecified 'cpu' resource for containers [nginx] (see http://g.co/gke/autopilot-defaults).
deployment.apps/web-service created
Error: quiet mode requires a query to be provided as a positional argument
Usage:
  kubectl-ai [flags]
  kubectl-ai [command]

Available Commands:
  completion  Generate the autocompletion script for the specified shell
  help        Help about any command
  version     Print the version number of kubectl-ai

Flags:
      --custom-tools-config stringArray    path to custom tools config file or directory (default [{CONFIG}/kubectl-ai/tools.yaml,{HOME}/.config/kubectl-ai/tools.yaml])
      --enable-tool-use-shim               enable tool use shim
      --extra-prompt-paths stringArray     extra prompt template paths
  -h, --help                               help for kubectl-ai
      --kubeconfig string                  path to kubeconfig file
      --llm-provider string                language model provider (default "gemini")
      --max-iterations int                 maximum number of iterations agent will try before giving up (default 20)
      --mcp-server                         run in MCP server mode
      --model string                       language model e.g. gemini-2.0-flash-thinking-exp-01-21, gemini-2.0-flash (default "gemini-2.5-pro-preview-03-25")
      --prompt-template-file-path string   path to custom prompt template file
      --quiet                              run in non-interactive mode, requires a query to be provided as a positional argument
      --remove-workdir                     remove the temporary working directory after execution
      --skip-permissions                   (dangerous) skip asking for confirmation before executing kubectl commands that modify resources
      --skip-verify-ssl                    skip verifying the SSL certificate of the LLM provider
      --trace-path string                  path to the trace file (default "/tmp/kubectl-ai-trace.txt")
      --user-interface UserInterface       user interface mode to use. Supported values: terminal, html. (default terminal)
  -v, --v Level                            number for the log level verbosity

Use "kubectl-ai [command] --help" for more information about a command.

quiet mode requires a query to be provided as a positional argument
```

I did some quick look up, so doing a size check on stdin seems to work on Mac fine, but fails on linux. Some more digging suggests that this behavior depends on the OS and is hard to make portable. Confirmed by [this post](https://github.com/golang/go/issues/62392). 

```Go

         if stat.Size() == 0 {
		return false, nil
	}
```

@mikebz I am reverting this change until we figure out a portable way to address this issue.

