### PR TITLE
Fix error when trying to include multi-line string in conversation output when using --enable-tool-use-shim

### DIFF
--- a/pkg/agent/conversation.go
+++ b/pkg/agent/conversation.go
@@ -505,10 +505,6 @@ func candidateToShimCandidate(iterator gollm.ChatResponseIterator) (gollm.ChatRe
 					return
 				}
 			}
-
-			if _, found := extractJSON(buffer); found {
-				break
-			}
 		}
 
 		if buffer == "" {


### PR DESCRIPTION
Proposed fix for issue in #296.

At the end of the given error message, we see:
`Here are a few examples from the logs:\\n": unexpected end of JSON input`
suggesting there should be some examples printed after this.

I found the easiest way to recreate this was to just ask about logs and try to get it to copy/paste a section for the user to view. This only happens with --enable-tool-use-shim flag, because candidateToShimCandidate() is guarded behind a check for this flag.

With some investigating, I found the program trying to embed a multi-line string in its output, delimited by ` ``` `. extractJSON() will return saying that valid JSON is found when it finds ` ```json ` opener and ` ``` ` closer. In candidateToShimCandidate(), as it iterates through the stream, it will find the start of the embedded multi-line string and consider that the json closer, thus breaking out of the loop and trying to parse a ReActResponse with the incomplete JSON, causing the error.

It looks like the only purpose of this extractJSON() call is to cut the loop short, since the outputted JSON is not used and the same extractJSON() is called in the first line of parseReActResponse().