### PR TITLE
feat: add Dependabot configuration for GitHub Actions and Go modules

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,23 @@
+# Refer to the official Dependabot documentation for all configuration options:
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  # Configuration for GitHub Actions
+  # See: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#package-ecosystem
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    # doing weekly because to have them done in bulk
+
+  # Configuration for Go modules
+  # See: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#package-ecosystem
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    update-types:
+      - "minor"
+      - "patch"
+    # the major updates are probably going to break code and therefore best left to manual updates


### PR DESCRIPTION
This pull request introduces a new `.github/dependabot.yaml` configuration file to automate dependency updates for the project. It includes configurations for GitHub Actions and Go modules, specifying update intervals and types.

### Dependabot Configuration:
* Added a `dependabot.yml` file to enable automated dependency updates. The configuration includes:
  - Weekly updates for GitHub Actions dependencies (`package-ecosystem: "github-actions"`) with updates applied to the root directory.
  - Weekly updates for Go modules (`package-ecosystem: "gomod"`) with minor and patch updates only, avoiding major updates to prevent breaking changes.