### PR TITLE
fix and improve the observation format

### DIFF
--- a/pkg/agent/conversation.go
+++ b/pkg/agent/conversation.go
@@ -248,7 +248,7 @@ func (a *Conversation) RunOneRound(ctx context.Context, query string) error {
 
 				if a.EnableToolUseShim {
 					// Add the error as an observation
-					observation := fmt.Sprintf("Result of running %q:\n%s", call.Name, err.Error())
+					observation := fmt.Sprintf("Result of running %q:\n%v", call.Name, err)
 					currChatContent = append(currChatContent, observation)
 				} else {
 					// For models with tool-use support (shim disabled), use proper FunctionCallResult
@@ -330,7 +330,7 @@ func (a *Conversation) RunOneRound(ctx context.Context, query string) error {
 			// Add the tool call result to maintain conversation flow
 			if a.EnableToolUseShim {
 				// If shim is enabled, format the result as a text observation
-				observation := fmt.Sprintf("Result of running %q:\n%s", call.Name, output)
+				observation := fmt.Sprintf("Result of running %q:\n%v", call.Name, output)
 				currChatContent = append(currChatContent, observation)
 			} else {
 				// If shim is disabled, convert the result to a map and append FunctionCallResult


### PR DESCRIPTION
#### Problem 1: Potential Nil Pointer Exception

In the current implementation, the following code assumes err is non-nil, which may lead to a nil pointer dereference when formatting the observation:

```
observation := fmt.Sprintf("Result of running %q:\n%s", call.Name, err.Error())
```

This PR ensures that we avoid accessing err.Error() when err is nil.


#### Problem 2: Insufficient Context in Observations

Previously, when shim execution was enabled, the observation string lacked sufficient context:

```
observation := fmt.Sprintf("Result of running %q:\n%s", call.Name, output)
```

As a result, the serialized observation in the request message looked like this:

```
{
"messages": [
	...
	{
		"content": "Result of running \"kubectl\":\n&{ apiVersion: apps/v1\n...",
		"role": "user"
	},
	...
	{
		"content": "Result of running \"kubectl\":&{  error: unknown flag: --readiness ...}",
		"role": "user"
	},
	...
]
```

These formats omit execution context such as the command string, exit code, and stderr. This lack of detail negatively impacts the task’s success rate by making it harder for LLM to understand execution results.

To address these issues, I added a structured serializer for the ExecResult type:

```
func (e *ExecResult) String() string {
	return fmt.Sprintf("Command: %q\nError: %q\nStdout: %q\nStderr: %q\nExitCode: %d\nStreamType: %q}", e.Command, e.Error, e.Stdout, e.Stderr, e.ExitCode, e.StreamType)
}
```

With this change, the observation format becomes significantly more informative:


```
{
"messages": [
	...
	{
		"content": "Result of running \"kubectl\":\nCommand: \"/bin/bash -c kubectl patch deployment webapp -n health-check...\nStdout: \"deployment.apps/webapp patched\n\"\nStderr: \"\"\nExitCode: 0\nStreamType: \"\"",
		"role": "user"
	},
	...
]
```

This improvement provides better context for LLM to understand execution results and has led to a noticeable increase in task success rate, while also reducing redundant actions during execution.


