### PR TITLE
Fix NPE in conversation.go

### DIFF
--- a/pkg/tools/tools.go
+++ b/pkg/tools/tools.go
@@ -182,7 +182,7 @@ func (t *ToolCall) InvokeTool(ctx context.Context, opt InvokeToolOptions) (any, 
 		})
 	}
 
-	return response, nil
+	return response, err
 }
 
 // ToolResultToMap converts an arbitrary result to a map[string]any


### PR DESCRIPTION
When I run some tests, I encounter a nil pointer dereference in conversation.go. 

```
  Running: scan_image_with_trivy(image=web-app:1.22)
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x50 pc=0x105a86810]

goroutine 1 [running]:
github.com/GoogleCloudPlatform/kubectl-ai/pkg/agent.(*Conversation).RunOneRound(0x14000030180, {0x10623e610, 0x106be1100}, {0x140005b2000, 0x81})
	/Users/denverdino/work/agent-learning/kubectl-ai/pkg/agent/conversation.go:326 +0x1100
main.(*session).answerQuery(0x140004d7878, {0x10623e610?, 0x106be1100?}, {0x140005b2000?, 0x0?})
	/Users/denverdino/work/agent-learning/kubectl-ai/cmd/main.go:612 +0x528
main.RunRootCommand({0x10623e610, 0x106be1100}, {{0x16aea706b, 0x6}, {0x16aea70a4, 0xf}, 0x1, 0x0, 0x1, 0x0, ...}, ...)
···
```

And I found that in ```pkg/tools/tools.go```, the InvokeTool call’s error return is ignored. Then the following code in  ```conversation.go```  cannot check the err properly

```
	output, err := toolCall.InvokeTool(ctx, tools.InvokeToolOptions{
		Kubeconfig: a.Kubeconfig,
		WorkDir:    a.workDir,
	})
	if err != nil {
		return fmt.Errorf("executing action: %w", err)
	}

	// Handle timeout message using UI blocks
	if execResult, ok := output.(*tools.ExecResult); ok && execResult.StreamType == "timeout" {
		a.doc.AddBlock(ui.NewAgentTextBlock().WithText("\nTimeout reached after 7 seconds\n"))
	}
```

