### PR TITLE
Change eval's expect block to parse stdout

### DIFF
--- a/k8s-bench/eval.go
+++ b/k8s-bench/eval.go
@@ -410,12 +410,11 @@ func (x *TaskExecution) runAgent(ctx context.Context) error {
 			lastToolRunIndex := strings.LastIndex(agentOutput, "Running:")
 			lastOutputIndex := strings.Index(agentOutput[lastToolRunIndex:], "\n")
 
-			lastCmdOutputIndex := lastToolRunIndex + lastOutputIndex + 1
+			lastCmdOutput := agentOutput[lastToolRunIndex+lastOutputIndex+1:]
 			if lastToolRunIndex == -1 {
 				// if no tool run found, parse the entire output
-				lastCmdOutputIndex = 0
+				lastCmdOutput = agentOutput
 			}
-			lastCmdOutput := agentOutput[lastCmdOutputIndex:]
 			if !strings.Contains(lastCmdOutput, expect.Contains) {
 				x.result.AddFailure("expected value %q not found in output %q", expect.Contains, lastCmdOutput)
 				return fmt.Errorf("expected value %q not found in agent output", expect.Contains)

--- a/k8s-bench/go.mod
+++ b/k8s-bench/go.mod
@@ -7,9 +7,11 @@ toolchain go1.24.1
 replace github.com/GoogleCloudPlatform/kubectl-ai => ./..
 
 require (
-	github.com/GoogleCloudPlatform/kubectl-ai v0.0.0-20250317140348-3b34c8984b9b
 	k8s.io/klog/v2 v2.130.1
 	sigs.k8s.io/yaml v1.4.0
 )
 
-require github.com/go-logr/logr v1.4.2 // indirect
+require (
+	github.com/go-logr/logr v1.4.2 // indirect
+	github.com/google/go-cmp v0.6.0 // indirect
+)


### PR DESCRIPTION
Currently including `expect` line in an eval's task.yaml won't actually run these checks, since the `journal.ActionUIRender` got obsoleted somewhere in the past. This means that running an eval now that *only* relies on the expect block like #295, will always succeed as long as there are no other errors during the run.

This fix saves a copy of stdout from running the eval, parses for the final llm response, and checks if it contains the expected text.

Another option could be to stick with the journal checking, and any time we write to sdout include a journal entry, like https://github.com/GoogleCloudPlatform/kubectl-ai/blob/4d4005ae9c1831ccb61b1d27bf86a68b1917fc5a/pkg/agent/conversation.go#L190, but I decided against it since it seems like a higher-maintenance option.