### PR TITLE
eval: add create-simple-rbac eval

### DIFF
--- a/k8s-bench/tasks/create-simple-rbac/cleanup.sh
+++ b/k8s-bench/tasks/create-simple-rbac/cleanup.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+kubectl delete namespace create-simple-rbac --ignore-not-found=true

--- a/k8s-bench/tasks/create-simple-rbac/setup.sh
+++ b/k8s-bench/tasks/create-simple-rbac/setup.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+kubectl delete namespace create-simple-rbac --ignore-not-found # clean up, just in case
+kubectl create namespace create-simple-rbac
+kubectl create serviceaccount reader-sa -n create-simple-rbac

--- a/k8s-bench/tasks/create-simple-rbac/task.yaml
+++ b/k8s-bench/tasks/create-simple-rbac/task.yaml
@@ -1,0 +1,6 @@
+script:
+- prompt: "Create a read-only role for pods bound to my reader-sa service account in the create-simple-rbac namespace."
+setup: "setup.sh"
+verifier: "verify.sh"
+cleanup: "cleanup.sh"
+difficulty: "medium"

--- a/k8s-bench/tasks/create-simple-rbac/verify.sh
+++ b/k8s-bench/tasks/create-simple-rbac/verify.sh
@@ -26,5 +26,10 @@ if kubectl auth can-i create pods --as=$SERVICE_ACCOUNT_USER -n $NAMESPACE &> /d
   exit 1
 fi
 
+if kubectl auth can-i create pods --as=$SERVICE_ACCOUNT_USER &> /dev/null; then
+  echo "ServiceAccount has excessive permissions (can 'create' pods in other namespace)."
+  exit 1
+fi
+
 echo "Verification successful: RBAC role and binding correctly configured."
 exit 0

--- a/k8s-bench/tasks/create-simple-rbac/verify.sh
+++ b/k8s-bench/tasks/create-simple-rbac/verify.sh
@@ -31,5 +31,10 @@ if kubectl auth can-i create pods --as=$SERVICE_ACCOUNT_USER &> /dev/null; then
   exit 1
 fi
 
+if kubectl auth can-i list pods --as=$SERVICE_ACCOUNT_USER -A &> /dev/null; then
+  echo "ServiceAccount has excessive permissions (can 'list' pods in other namespace)."
+  exit 1
+fi
+
 echo "Verification successful: RBAC role and binding correctly configured."
 exit 0

--- a/k8s-bench/tasks/create-simple-rbac/verify.sh
+++ b/k8s-bench/tasks/create-simple-rbac/verify.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+NAMESPACE="create-simple-rbac"
+SERVICE_ACCOUNT="reader-sa"
+SERVICE_ACCOUNT_USER="system:serviceaccount:${NAMESPACE}:${SERVICE_ACCOUNT}"
+
+# Check for allowed permissions
+if ! kubectl auth can-i get pods --as=$SERVICE_ACCOUNT_USER -n $NAMESPACE &> /dev/null; then
+    echo "ServiceAccount cannot 'get' pods."
+    exit 1
+fi
+
+if ! kubectl auth can-i list pods --as=$SERVICE_ACCOUNT_USER -n $NAMESPACE &> /dev/null; then
+    echo "ServiceAccount cannot 'list' pods."
+    exit 1
+fi
+
+# Check for denied permissions
+if kubectl auth can-i delete pods --as=$SERVICE_ACCOUNT_USER -n $NAMESPACE &> /dev/null; then
+  echo "ServiceAccount has excessive permissions (can 'delete' pods)."
+  exit 1
+fi
+
+if kubectl auth can-i create pods --as=$SERVICE_ACCOUNT_USER -n $NAMESPACE &> /dev/null; then
+  echo "ServiceAccount has excessive permissions (can 'create' pods)."
+  exit 1
+fi
+
+echo "Verification successful: RBAC role and binding correctly configured."
+exit 0


### PR DESCRIPTION
Adds create-simple-rbac eval. The goal of this eval is to cover the case of the agent creating a pods read-only RBAC setup for an existing service account.
-verify checks for expected and denied permissions