### PR TITLE
eval: Add fix-rbac-wrong-resource eval

### DIFF
--- a/k8s-bench/tasks/fix-rbac-wrong-resource/cleanup.sh
+++ b/k8s-bench/tasks/fix-rbac-wrong-resource/cleanup.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+kubectl delete namespace simple-rbac-setup --ignore-not-found

--- a/k8s-bench/tasks/fix-rbac-wrong-resource/setup.sh
+++ b/k8s-bench/tasks/fix-rbac-wrong-resource/setup.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+kubectl delete namespace simple-rbac-setup --ignore-not-found
+kubectl create namespace simple-rbac-setup
+kubectl create serviceaccount pod-reader -n simple-rbac-setup
+# role is misconfigured to list deployments instead of pods
+kubectl create role pod-reader-role --verb=list --resource=deployments -n simple-rbac-setup
+kubectl create rolebinding pod-reader-binding --role=pod-reader-role --serviceaccount=simple-rbac-setup:pod-reader -n simple-rbac-setup

--- a/k8s-bench/tasks/fix-rbac-wrong-resource/task.yaml
+++ b/k8s-bench/tasks/fix-rbac-wrong-resource/task.yaml
@@ -1,0 +1,6 @@
+script:
+- prompt: "Why can't I list pods with my pod-reader service account? Please fix it."
+setup: "setup.sh"
+verifier: "verify.sh"
+cleanup: "cleanup.sh"
+difficulty: "easy"

--- a/k8s-bench/tasks/fix-rbac-wrong-resource/verify.sh
+++ b/k8s-bench/tasks/fix-rbac-wrong-resource/verify.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+NAMESPACE=simple-rbac-setup
+SERVICE_ACCOUNT=pod-reader
+SERVICE_ACCOUNT_USER="system:serviceaccount:${NAMESPACE}:${SERVICE_ACCOUNT}"
+
+# Check for allowed permissions
+if ! kubectl auth can-i list pods --as=${SERVICE_ACCOUNT_USER} -n=${NAMESPACE} &> /dev/null; then
+    echo "ServiceAccount still can't list pods."
+    exit 1
+fi
+
+# Check for denied permissions
+if kubectl auth can-i list pods --as=${SERVICE_ACCOUNT_USER} -A &> /dev/null; then
+    echo "ServiceAccount has excessive permissions (can 'list' pods in other namespaces)."
+    exit 1
+fi
+
+echo "Verification successful: RBAC role correctly reconfigured."
+exit 0


### PR DESCRIPTION
Adds fix-rbac-wrong-resource eval. The goal of this eval is to cover the case of the agent fixing a misconfigured RBAC resource. In this case, the permissions are granted on the wrong resource type.
-verify checks for expected and denied permissions