### PR TITLE
resolve kubeconfig flag to absolute path

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -89,11 +89,15 @@ type Options struct {
 	EnableToolUseShim bool `json:"enableToolUseShim,omitempty"`
 	// Quiet flag indicates if the agent should run in non-interactive mode.
 	// It requires a query to be provided as a positional argument.
-	Quiet                  bool     `json:"quiet,omitempty"`
-	MCPServer              bool     `json:"mcpServer,omitempty"`
-	MCPClient              bool     `json:"mcpClient,omitempty"`
-	MaxIterations          int      `json:"maxIterations,omitempty"`
-	KubeConfigPath         string   `json:"kubeConfigPath,omitempty"`
+	Quiet         bool `json:"quiet,omitempty"`
+	MCPServer     bool `json:"mcpServer,omitempty"`
+	MCPClient     bool `json:"mcpClient,omitempty"`
+	MaxIterations int  `json:"maxIterations,omitempty"`
+
+	// KubeConfigPath is the path to the kubeconfig file.
+	// If not provided, the default kubeconfig path will be used.
+	KubeConfigPath string `json:"kubeConfigPath,omitempty"`
+
 	PromptTemplateFilePath string   `json:"promptTemplateFilePath,omitempty"`
 	ExtraPromptPaths       []string `json:"extraPromptPaths,omitempty"`
 	TracePath              string   `json:"tracePath,omitempty"`
@@ -710,6 +714,15 @@ func resolveKubeConfigPath(opt *Options) error {
 			return fmt.Errorf("failed to get user home directory: %w", err)
 		}
 		opt.KubeConfigPath = filepath.Join(home, ".kube", "config")
+	}
+
+	// We resolve the kubeconfig path to an absolute path, so we can run kubectl from any working directory.
+	if opt.KubeConfigPath != "" {
+		p, err := filepath.Abs(opt.KubeConfigPath)
+		if err != nil {
+			return fmt.Errorf("failed to get absolute path for kubeconfig file %q: %w", opt.KubeConfigPath, err)
+		}
+		opt.KubeConfigPath = p
 	}
 
 	return nil

--- a/pkg/agent/conversation.go
+++ b/pkg/agent/conversation.go
@@ -50,7 +50,9 @@ type Conversation struct {
 
 	MaxIterations int
 
-	Kubeconfig      string
+	// Kubeconfig is the path to the kubeconfig file.
+	Kubeconfig string
+
 	SkipPermissions bool
 
 	Tools tools.Tools

--- a/pkg/tools/tools.go
+++ b/pkg/tools/tools.go
@@ -132,6 +132,7 @@ func (t *Tools) ParseToolInvocation(ctx context.Context, name string, arguments 
 type InvokeToolOptions struct {
 	WorkDir string
 
+	// Kubeconfig is the path to the kubeconfig file.
 	Kubeconfig string
 }
 


### PR DESCRIPTION
This lets us run kubectl from a temporary directory, even if the
--kubeconfig flag is set to a relative path in the current directory.

Issue #340
