### PR TITLE
feat(mcp): add argument serialization for JSON compatibility

### DIFF
--- a/pkg/mcp/http_client.go
+++ b/pkg/mcp/http_client.go
@@ -252,11 +252,19 @@ func (c *httpClient) CallTool(ctx context.Context, toolName string, arguments ma
 		return "", err
 	}
 
+	// Serialize arguments to ensure they are JSON-compatible
+	serializedArgs, err := SerializeArgsForMCP(arguments)
+	if err != nil {
+		return "", fmt.Errorf("serializing arguments for MCP tool %s: %w", toolName, err)
+	}
+
+	klog.V(3).InfoS("Serialized arguments for MCP tool", "server", c.name, "tool", toolName, "args", serializedArgs)
+
 	// Create v0.31.0 compatible request
 	request := mcp.CallToolRequest{
 		Params: mcp.CallToolParams{
 			Name:      toolName,
-			Arguments: arguments,
+			Arguments: serializedArgs,
 		},
 	}
 

--- a/pkg/mcp/stdio_client.go
+++ b/pkg/mcp/stdio_client.go
@@ -149,11 +149,19 @@ func (c *stdioClient) CallTool(ctx context.Context, toolName string, arguments m
 		return "", err
 	}
 
+	// Serialize arguments to ensure they are JSON-compatible
+	serializedArgs, err := SerializeArgsForMCP(arguments)
+	if err != nil {
+		return "", fmt.Errorf("serializing arguments for MCP tool %s: %w", toolName, err)
+	}
+
+	klog.V(3).InfoS("Serialized arguments for MCP tool", "server", c.name, "tool", toolName, "args", serializedArgs)
+
 	// Create v0.31.0 compatible request
 	request := mcp.CallToolRequest{
 		Params: mcp.CallToolParams{
 			Name:      toolName,
-			Arguments: arguments,
+			Arguments: serializedArgs,
 		},
 	}
 


### PR DESCRIPTION
## Summary
This update refactors the `SerializeArgsForMCP` function to improve argument serialization for MCP servers. It now recursively handles nested structures such as maps and slices, and converts complex types using JSON marshaling and unmarshaling, ensuring all arguments are in proper JSON-compatible formats before transmission.

## Affected Modules
- `pkg/mcp/utils.go`: serialization utility functions.
- `pkg/mcp/http_client.go`, `pkg/mcp/stdio_client.go`: argument preparation during tool calls.

## Key Details
- **Serialization Strategy:**
  - Recursively serializes nested `map[string]any` and `[]any`.
  - Uses JSON marshaling/unmarshaling as a fallback for complex or custom types, ensuring broad type coverage.
  - Handles primitive types directly.
- **Function Changes:**
  - `SerializeArgsForMCP`: now performs deep serialization and type normalization.
  - `serializeValue`: new recursive helper function, converting values to JSON-compatible representations.
- **Error Handling:** Provides informative errors during complex serialization failures.
