### PR TITLE
mcp client: don't mangle arguments

### DIFF
--- a/pkg/mcp/client.go
+++ b/pkg/mcp/client.go
@@ -149,11 +149,6 @@ func (c *Client) CallTool(ctx context.Context, toolName string, arguments map[st
 		return "", err
 	}
 
-	// Ensure we have a valid context
-	if ctx == nil {
-		ctx = context.Background()
-	}
-
 	// Delegate to implementation
 	return c.impl.CallTool(ctx, toolName, arguments)
 }

--- a/pkg/tools/mcp_tool.go
+++ b/pkg/tools/mcp_tool.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/kubectl-ai/gollm"
 	"github.com/GoogleCloudPlatform/kubectl-ai/pkg/mcp"
+	"k8s.io/klog/v2"
 )
 
 // =============================================================================
@@ -108,18 +109,22 @@ func (t *MCPTool) CheckModifiesResource(args map[string]any) string {
 
 // Run executes the MCP tool by calling the appropriate MCP server.
 func (t *MCPTool) Run(ctx context.Context, args map[string]any) (any, error) {
+	log := klog.FromContext(ctx)
+
 	// Get MCP client for the server
 	client, exists := t.manager.GetClient(t.serverName)
 	if !exists {
 		return nil, fmt.Errorf("MCP server %q not connected", t.serverName)
 	}
 
-	// Convert arguments to proper types for MCP server using the MCP package's functions
-	convertedArgs := mcp.ConvertArgs(args)
+	// // Convert arguments to proper types for MCP server using the MCP package's functions
+	// args = mcp.ConvertArgs(args)
 
 	// Execute tool on MCP server
-	result, err := client.CallTool(ctx, t.toolName, convertedArgs)
+	result, err := client.CallTool(ctx, t.toolName, args)
 	if err != nil {
+		log.Info("tool info", "name", t.toolName, "schema", t.schema)
+		log.Info("call info", "args", args)
 		return nil, fmt.Errorf("calling MCP tool %q on server %q: %w", t.toolName, t.serverName, err)
 	}
 


### PR DESCRIPTION
I don't think we should be mangling the arguments,
once we pass the schema the LLM seems to do a reasonable job.
