### PR TITLE
Add issue templates for bug reports and feature requests (#269)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,25 @@
+---
+name: 🐞 Bug Report
+about: Report a reproducible bug or issue
+title: "[Bug]: <describe bug>"
+labels: bug
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Run command '...'
+3. See error
+
+**Expected behavior**
+What you expected to happen.
+
+**Environment (please complete the following):**
+ - OS: [e.g. Ubuntu 22.04]
+ - kubectl-ai version: [e.g. 0.3.0]
+
+**Additional context**
+Add any other context or logs here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,18 @@
+---
+name: 🚀 Feature Request
+about: Suggest an idea for a new feature or improvement
+title: "[Feature]: <describe your idea>"
+labels: enhancement
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear description of the problem you're trying to solve.
+
+**Describe the solution you'd like**
+A clear description of what you want to happen.
+
+**Describe alternatives you've considered**
+Any alternative solutions or features you’ve thought of.
+
+**Additional context**
+Add any other context, links, or screenshots here.


### PR DESCRIPTION
This PR adds GitHub issue templates as part of issue #269.

- 🐞 `bug_report.md`
- 🚀 `feature_request.md`

These templates will make it easier for users to report bugs or suggest features in a structured way.
