### PR TITLE
Allow making width configurable for kubectl-ai's terminal UI

### DIFF
--- a/pkg/ui/terminal.go
+++ b/pkg/ui/terminal.go
@@ -54,12 +54,34 @@ type TerminalUI struct {
 
 var _ UI = &TerminalUI{}
 
+func getCustomTerminalWidth() int {
+	// Check for user-configured width via environment variable
+	if widthStr := os.Getenv("KUBECTL_AI_TERM_WIDTH"); widthStr != "" {
+		if width, err := strconv.Atoi(widthStr); err == nil && width > 0 {
+			return width
+		}
+		klog.Warningf("Invalid KUBECTL_AI_TERM_WIDTH value %q, using default", widthStr)
+	}
+
+	// Return 0 to indicate no custom width should be set (use glamour's default)
+	return 0
+}
+
 func NewTerminalUI(doc *Document, journal journal.Recorder, useTTYForInput bool) (*TerminalUI, error) {
-	mdRenderer, err := glamour.NewTermRenderer(
+	width := getCustomTerminalWidth()
+
+	options := []glamour.TermRendererOption{
 		glamour.WithAutoStyle(),
 		glamour.WithPreservedNewLines(),
 		glamour.WithEmoji(),
-	)
+	}
+
+	// Only add WordWrap if a valid width is configured
+	if width > 0 {
+		options = append(options, glamour.WithWordWrap(width))
+	}
+
+	mdRenderer, err := glamour.NewTermRenderer(options...)
 	if err != nil {
 		return nil, fmt.Errorf("error initializing the markdown renderer: %w", err)
 	}


### PR DESCRIPTION
With the default fixed width of 80 (in the glamour library), I find a lot of my screen real estate getting wasted and a lot of scrolling needed when I run kubectl-ai on my terminal, so I wanted to tackle this.

There are few different paths to tackle this and honestly I am bit dicey about the path I took but here is my thinking:
1. I didn't want to figure the terminal width using one of the standard ways (`term.GetSize` or `COLUMNS` env var) since then the change would affect most of the folks by default.
2. I didn't want to add a new `--width` flag just for this.
3. I went with a totally custom env var approach so that only folks who really want this can use it.

I am open to thoughts and folks preferring some other path over this path, LMK.