### PR TITLE
feat: modularize prompt resolution with new `promptFile`

### DIFF
--- a/k8s-bench/eval.go
+++ b/k8s-bench/eval.go
@@ -393,7 +393,14 @@ func (x *TaskExecution) runAgent(ctx context.Context) error {
 	go func() {
 		// TODO: Wait for idle between sending steps?
 		for _, step := range x.task.Script {
-			fmt.Fprintf(stdinWriter, "%s\n", step.Prompt)
+			prompt, err := step.ResolvePrompt(x.taskDir)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Error resolving prompt: %v\n", err)
+				x.result.AddFailure("failed to resolve prompt: %v", err)
+				stdinWriter.Close()
+				return
+			}
+			fmt.Fprintf(stdinWriter, "%s\n", prompt)
 		}
 		stdinWriter.Close()
 	}()

--- a/k8s-bench/main.go
+++ b/k8s-bench/main.go
@@ -59,7 +59,12 @@ type ScriptStep struct {
 
 // ResolvePrompt resolves the prompt from either inline or file source
 func (s *ScriptStep) ResolvePrompt(baseDir string) (string, error) {
-	// If both are provided, promptFile takes precedence
+	// Fail if both prompt and promptFile are provided to avoid confusion
+	if s.Prompt != "" && s.PromptFile != "" {
+		return "", fmt.Errorf("both 'prompt' and 'promptFile' are specified in script step; only one should be provided")
+	}
+
+	// If promptFile is provided, read the file
 	if s.PromptFile != "" {
 		// If the path is relative, resolve it relative to the task directory
 		promptPath := s.PromptFile
@@ -75,7 +80,7 @@ func (s *ScriptStep) ResolvePrompt(baseDir string) (string, error) {
 		return string(content), nil
 	}
 
-	// If no promptFile, use inline prompt
+	// If prompt is provided, use it
 	if s.Prompt != "" {
 		return s.Prompt, nil
 	}

--- a/k8s-bench/tasks/setup-dev-cluster/setup-dev-cluster.md
+++ b/k8s-bench/tasks/setup-dev-cluster/setup-dev-cluster.md
@@ -1,0 +1,26 @@
+You are a Kubernetes administrator setting up a development cluster for a team of 3 developers (alice, bob, and charlie).
+
+Create a secure, multi-tenant development environment with the following requirements:
+
+1. **Namespaces**: Create separate namespaces for each developer (dev-alice, dev-bob, dev-charlie) plus shared namespaces (dev-shared, staging, prod)
+
+2. **RBAC Configuration**:
+    - Each developer should have full access to their own namespace
+    - Developers should have read-only access to the dev-shared namespace
+    - Only cluster admins should access staging and prod
+    - Create service accounts for each developer (alice-sa, bob-sa, charlie-sa) in their respective namespaces
+
+3. **Resource Quotas**:
+    - Each developer namespace: max 2 CPUs, 4Gi memory, 10 pods, 5 services
+    - dev-shared namespace: max 4 CPUs, 8Gi memory, 20 pods, 10 services  
+    - staging/prod: max 8 CPUs, 16Gi memory, 50 pods, 20 services
+
+4. **Network Policies**:
+    - Developers can only access their own namespace and dev-shared
+    - Block cross-developer namespace communication
+    - Allow all namespaces to access DNS and system services
+    - staging and prod should be completely isolated from dev namespaces
+
+5. **Default Deny Policies**: Implement default deny network policies for all namespaces except system namespaces
+
+Ensure all configurations follow principle of least privilege and provide appropriate isolation between environments.

--- a/k8s-bench/tasks/setup-dev-cluster/task.yaml
+++ b/k8s-bench/tasks/setup-dev-cluster/task.yaml
@@ -1,30 +1,5 @@
 script:
-   - prompt: |
-        You are a Kubernetes administrator setting up a development cluster for a team of 3 developers (alice, bob, and charlie).
-        Create a secure, multi-tenant development environment with the following requirements:
-
-        1. **Namespaces**: Create separate namespaces for each developer (dev-alice, dev-bob, dev-charlie) plus shared namespaces (dev-shared, staging, prod)
-
-        2. **RBAC Configuration**:
-           - Each developer should have full access to their own namespace
-           - Developers should have read-only access to the dev-shared namespace
-           - Only cluster admins should access staging and prod
-           - Create service accounts for each developer (alice-sa, bob-sa, charlie-sa) in their respective namespaces
-
-        3. **Resource Quotas**:
-           - Each developer namespace: max 2 CPUs, 4Gi memory, 10 pods, 5 services
-           - dev-shared namespace: max 4 CPUs, 8Gi memory, 20 pods, 10 services  
-           - staging/prod: max 8 CPUs, 16Gi memory, 50 pods, 20 services
-
-        4. **Network Policies**:
-           - Developers can only access their own namespace and dev-shared
-           - Block cross-developer namespace communication
-           - Allow all namespaces to access DNS and system services
-           - staging and prod should be completely isolated from dev namespaces
-
-        5. **Default Deny Policies**: Implement default deny network policies for all namespaces except system namespaces
-
-        Ensure all configurations follow principle of least privilege and provide appropriate isolation between environments.
+   - promptFile: setup-dev-cluster.md
 
 difficulty: hard
 setup: setup.sh


### PR DESCRIPTION
This PR adds the ability to store task prompts in external files instead of embedding them directly in YAML configurations.

### Key Changes
- Added `PromptFile` field to `ScriptStep` struct
- Implemented `ResolvePrompt()` method to load prompts from files or inline content
- Refactored `setup-dev-cluster` task to use external `setup-dev-cluster.md` file
- Maintains full backward compatibility with existing inline prompts

### Benefits
- Cleaner YAML configurations
- Better maintainability for complex prompts
- Improved editing experience with markdown files
- Supports both absolute and relative file paths