### PR TITLE
add auto support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/mark3labs/mcp-go v0.31.0
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.6
+	golang.org/x/term v0.31.0
 	k8s.io/klog/v2 v2.130.1
 	mvdan.cc/sh/v3 v3.11.0
 	sigs.k8s.io/yaml v1.4.0
@@ -80,7 +81,6 @@ require (
 	golang.org/x/crypto v0.36.0 // indirect
 	golang.org/x/net v0.38.0 // indirect
 	golang.org/x/sys v0.32.0 // indirect
-	golang.org/x/term v0.31.0 // indirect
 	golang.org/x/text v0.24.0 // indirect
 	google.golang.org/genai v1.8.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250219182151-9fdb1cabc7b2 // indirect

--- a/pkg/ui/terminal.go
+++ b/pkg/ui/terminal.go
@@ -27,6 +27,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubectl-ai/pkg/journal"
 	"github.com/charmbracelet/glamour"
 	"github.com/chzyer/readline"
+	"golang.org/x/term"
 	"k8s.io/klog/v2"
 )
 
@@ -57,6 +58,18 @@ var _ UI = &TerminalUI{}
 func getCustomTerminalWidth() int {
 	// Check for user-configured width via environment variable
 	if widthStr := os.Getenv("KUBECTL_AI_TERM_WIDTH"); widthStr != "" {
+
+		if widthStr == "auto" {
+			width, _, err := term.GetSize(int(os.Stdout.Fd()))
+
+			if err != nil {
+				klog.Warningf("Failed to get terminal size: %v, using default width", err)
+				return 0
+			}
+
+			return width
+		}
+
 		if width, err := strconv.Atoi(widthStr); err == nil && width > 0 {
 			return width
 		}


### PR DESCRIPTION
Adds support for `KUBECTL_AI_TERM_WIDTH=auto` as outlined here: #396 