### PR TITLE
Change task expectations to use regexp

### DIFF
--- a/k8s-bench/eval.go
+++ b/k8s-bench/eval.go
@@ -243,12 +243,58 @@ func evaluateTask(ctx context.Context, config EvalConfig, taskID string, task Ta
 	}
 
 	// Run the agent
-	if err := x.runAgent(ctx); err != nil {
+	agentOutput, err := x.runAgent(ctx)
+	if err != nil {
 		// Unexpected error
 		result.Error = err.Error()
 		return result
 	}
 
+	expectationsMet := false
+	var expectationFailures []model.Failure
+	if len(task.Expect) > 0 {
+		expectationsMet = true
+
+		// find the output after the last run command and search it
+		var lastCmdOutput string
+		lastToolRunIndex := strings.LastIndex(agentOutput, "Running:")
+		if lastToolRunIndex == -1 {
+			// if no tool run found, parse the entire output
+			lastCmdOutput = agentOutput
+		} else {
+			remaining := agentOutput[lastToolRunIndex:]
+			newlineIndex := strings.Index(remaining, "\n")
+			if newlineIndex != -1 {
+				lastCmdOutput = remaining[newlineIndex+1:]
+			}
+			// if no newline, lastCmdOutput is empty string
+		}
+
+		for _, expect := range task.Expect {
+			if expect.Contains != "" {
+				re, err := regexp.Compile(expect.Contains)
+				if err != nil {
+					expectationFailures = append(expectationFailures, model.Failure{
+						Message: fmt.Sprintf("invalid regex %q in task spec: %v", expect.Contains, err),
+					})
+					expectationsMet = false
+					continue
+				}
+				if !re.MatchString(lastCmdOutput) {
+					expectationFailures = append(expectationFailures, model.Failure{
+						Message: fmt.Sprintf("regex %q did not match output %q", expect.Contains, lastCmdOutput),
+					})
+					expectationsMet = false
+				}
+			}
+		}
+
+		if expectationsMet {
+			fmt.Printf("\nAll output expectations met\n")
+		}
+	}
+
+	verifierSucceeded := false
 	// Run verifier if specified
 	if task.Verifier != "" {
 		verifierPath := filepath.Join(taskDir, task.Verifier)
@@ -258,14 +304,17 @@ func evaluateTask(ctx context.Context, config EvalConfig, taskID string, task Ta
 
 		err := x.runCommand(cmd)
 		if err == nil {
-			result.Result = "success"
-		} else if _, ok := err.(*exec.ExitError); ok {
-			// "Normal" script failure
-			result.Result = "fail"
+			verifierSucceeded = true
 		} else {
-			// Unexpected error
-			result.Error = err.Error()
+			result.AddFailure("verifier script failed")
 		}
+	}
+
+	if verifierSucceeded || expectationsMet {
+		result.Result = "success"
+	} else {
+		result.Result = "fail"
+		result.Failures = append(result.Failures, expectationFailures...)
 	}
 
 	return result
@@ -370,7 +419,7 @@ func (x *TaskExecution) runCleanup(ctx context.Context) error {
 	return errors.Join(errs...)
 }
 
-func (x *TaskExecution) runAgent(ctx context.Context) error {
+func (x *TaskExecution) runAgent(ctx context.Context) (string, error) {
 	tracePath := filepath.Join(x.taskOutputDir, "trace.yaml")
 
 	args := []string{
@@ -416,30 +465,10 @@ func (x *TaskExecution) runAgent(ctx context.Context) error {
 	}()
 
 	if err := cmd.Run(); err != nil {
-		return err
+		return "", err
 	}
 
-	// check any expectations
-	for _, expect := range x.task.Expect {
-		if expect.Contains != "" {
-			// find the output after the last run command and search it
-			agentOutput := stdoutBuffer.String()
-			lastToolRunIndex := strings.LastIndex(agentOutput, "Running:")
-			lastOutputIndex := strings.Index(agentOutput[lastToolRunIndex:], "\n")
-
-			lastCmdOutput := agentOutput[lastToolRunIndex+lastOutputIndex+1:]
-			if lastToolRunIndex == -1 {
-				// if no tool run found, parse the entire output
-				lastCmdOutput = agentOutput
-			}
-			if !strings.Contains(lastCmdOutput, expect.Contains) {
-				x.result.AddFailure("expected value %q not found in output %q", expect.Contains, lastCmdOutput)
-				return fmt.Errorf("expected value %q not found in agent output", expect.Contains)
-			}
-		}
-	}
-
-	return nil
+	return stdoutBuffer.String(), nil
 }
 
 func (x *TaskExecution) runCommand(cmd *exec.Cmd) error {

--- a/k8s-bench/tasks/create-pod/task.yaml
+++ b/k8s-bench/tasks/create-pod/task.yaml
@@ -3,3 +3,5 @@ script:
 verifier: "verify.sh"
 cleanup: "cleanup.sh"
 difficulty: "easy" 
+expect:
+- contains: "(nginx|proceed)"


### PR DESCRIPTION
In order to fix the flakiness in #392 we need to support checking against multiple outputs which can be accomplished through regex. This change also results in eval behavior changing when both verify and expect are specified, the result will be the logical OR between them.