### PR TITLE
feat: surface error messages from vertex-ai-client

### DIFF
--- a/gollm/gemini.go
+++ b/gollm/gemini.go
@@ -170,8 +170,9 @@ func NewVertexAIClient(ctx context.Context, opt VertexAIClientOptions) (*GoogleA
 	}
 
 	client, err := genai.NewClient(ctx, cc)
+
 	if err != nil {
-		return nil, fmt.Errorf("building gemini client: %w", err)
+		return nil, fmt.Errorf("building vertexai client: %w", err)
 	}
 
 	return &GoogleAIClient{
@@ -446,6 +447,13 @@ func (c *GeminiChat) SendStreaming(ctx context.Context, contents ...any) (ChatRe
 			if !ok {
 				return
 			}
+
+			if err != nil {
+				// Always check for and yield an error first.
+				yield(nil, err)
+				return
+			}
+
 			if geminiResponse == nil || len(geminiResponse.Candidates) == 0 {
 				return
 			}


### PR DESCRIPTION
Noticed while doing some of the containerization that some of the errors from the vertex-ai client would not be surfaced, such as credentials being missing:

Before: 
<img width="1728" height="960" alt="Screenshot 2025-07-21 at 3 01 37 PM" src="https://github.com/user-attachments/assets/e9cb7dee-d57f-4cb4-9759-45d928c3f7ac" />

After:
<img width="1728" height="991" alt="Screenshot 2025-07-21 at 2 54 50 PM" src="https://github.com/user-attachments/assets/e542e7bd-283a-407d-9d5a-fb5409ff471a" />
