### PR TITLE
feat: add Close method to UI interface and implement resource cleanup in REPL

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -468,6 +468,11 @@ func repl(ctx context.Context, initialQuery string, ui ui.UI, agent *agent.Agent
 		return fmt.Errorf("running UI: %w", err)
 	}
 
+	// Ensure UI resources are cleaned up
+	if closeErr := ui.Close(); closeErr != nil {
+		klog.Errorf("Error closing UI: %v", closeErr)
+	}
+
 	return nil
 }
 

--- a/pkg/ui/interfaces.go
+++ b/pkg/ui/interfaces.go
@@ -27,6 +27,9 @@ type UI interface {
 
 	// Run starts the UI and blocks until the context is done.
 	Run(ctx context.Context) error
+
+	// Close cleans up any resources used by the UI.
+	Close() error
 }
 
 // Type is the type of user interface.

--- a/pkg/ui/tui.go
+++ b/pkg/ui/tui.go
@@ -128,6 +128,13 @@ func (u *TUI) Run(ctx context.Context) error {
 func (u *TUI) ClearScreen() {
 }
 
+func (u *TUI) Close() error {
+	if u.program != nil {
+		u.program.Quit()
+	}
+	return nil
+}
+
 type resultMsg struct {
 	duration time.Duration
 	food     string


### PR DESCRIPTION
In this PR I have addressed https://github.com/GoogleCloudPlatform/kubectl-ai/issues/439#issuecomment-3140773328 by adding Close method to UI interface and implement resource cleanup in REPL

Closes https://github.com/GoogleCloudPlatform/kubectl-ai/issues/439
