### PR TITLE
fix: close terminal after 'exit' or 'quit'

### DIFF
--- a/pkg/agent/conversation.go
+++ b/pkg/agent/conversation.go
@@ -278,6 +278,12 @@ func (c *Agent) Run(ctx context.Context, initialQuery string) error {
 				c.pendingFunctionCalls = []ToolCallAnalysis{}
 				c.addMessage(api.MessageSourceAgent, api.MessageTypeError, "Error: "+err.Error())
 			} else if handled {
+				// initialQuery is the 'exit' or 'quit' metaquery
+				if c.AgentState() == api.AgentStateExited {
+					c.addMessage(api.MessageSourceAgent, api.MessageTypeText, answer)
+					c.Output <- ctx.Done()
+					return
+				}
 				// we handled the meta query, so we don't need to run the agentic loop
 				c.setAgentState(api.AgentStateDone)
 				c.pendingFunctionCalls = []ToolCallAnalysis{}
@@ -334,6 +340,12 @@ func (c *Agent) Run(ctx context.Context, initialQuery string) error {
 						continue
 					}
 					if handled {
+						// metaquery set the state to 'Exited', so we should exit
+						if c.AgentState() == api.AgentStateExited {
+							c.addMessage(api.MessageSourceAgent, api.MessageTypeText, answer)
+							c.Output <- ctx.Done()
+							return
+						}
 						// we handled the meta query, so we don't need to run the agentic loop
 						c.setAgentState(api.AgentStateDone)
 						c.pendingFunctionCalls = []ToolCallAnalysis{}


### PR DESCRIPTION
If meta query sets agent state to exited, then send done to output and exit.
- does not fix the behavior for tui

https://github.com/user-attachments/assets/854fd260-bd9e-4de8-bbef-810bffded4c0

