### PR TITLE
eval: Add blue/green traffic switch eval

### DIFF
--- a/k8s-bench/tasks/deployment-traffic-switch/artifacts/blue-deployment.yaml
+++ b/k8s-bench/tasks/deployment-traffic-switch/artifacts/blue-deployment.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: checkout-service-blue
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: checkout-service
+      version: blue
+  template:
+    metadata:
+      labels:
+        app: checkout-service
+        version: blue
+    spec:
+      containers:
+      - name: app
+        image: nginx:1.25
+        ports:
+        - containerPort: 80

--- a/k8s-bench/tasks/deployment-traffic-switch/artifacts/green-deployment.yaml
+++ b/k8s-bench/tasks/deployment-traffic-switch/artifacts/green-deployment.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: checkout-service-green
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: checkout-service
+      version: green
+  template:
+    metadata:
+      labels:
+        app: checkout-service
+        version: green
+    spec:
+      containers:
+      - name: app
+        image: nginx:1.26 # Use a different image tag to represent a new version
+        ports:
+        - containerPort: 80

--- a/k8s-bench/tasks/deployment-traffic-switch/artifacts/service.yaml
+++ b/k8s-bench/tasks/deployment-traffic-switch/artifacts/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: checkout-service
+spec:
+  selector:
+    # This selector initially targets the 'blue' version
+    app: checkout-service
+    version: blue
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 80

--- a/k8s-bench/tasks/deployment-traffic-switch/cleanup.sh
+++ b/k8s-bench/tasks/deployment-traffic-switch/cleanup.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+NAMESPACE="e-commerce"
+
+# Delete the namespace to clean up all resources created during the evaluation
+echo "Deleting namespace '$NAMESPACE'..."
+kubectl delete namespace $NAMESPACE --wait=false

--- a/k8s-bench/tasks/deployment-traffic-switch/setup.sh
+++ b/k8s-bench/tasks/deployment-traffic-switch/setup.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+NAMESPACE="e-commerce"
+
+# Create the namespace if it doesn't exist to make the script idempotent
+kubectl create namespace $NAMESPACE --dry-run=client -o yaml | kubectl apply -f -
+
+# Apply all resource manifests from the artifacts directory
+echo "Applying Kubernetes resources from artifacts/ directory..."
+kubectl apply -n $NAMESPACE -f artifacts/
+
+# Wait for both deployments to be available to ensure a stable starting state
+echo "Waiting for blue deployment to be ready..."
+kubectl rollout status deployment/checkout-service-blue -n $NAMESPACE --timeout=60s
+
+echo "Waiting for green deployment to be ready..."
+kubectl rollout status deployment/checkout-service-green -n $NAMESPACE --timeout=60s
+
+echo "Setup complete. Service 'checkout-service' is pointing to 'blue'."

--- a/k8s-bench/tasks/deployment-traffic-switch/task.yaml
+++ b/k8s-bench/tasks/deployment-traffic-switch/task.yaml
@@ -1,0 +1,6 @@
+script:
+  - prompt: "Our new checkout-service-green deployment in the e-commerce namespace has passed all tests. The current live version is checkout-service-blue. Can you switch all live traffic over to the green version now?"
+setup: "setup.sh"
+verifier: "verify.sh"
+cleanup: "cleanup.sh"
+difficulty: "easy"

--- a/k8s-bench/tasks/deployment-traffic-switch/verify.sh
+++ b/k8s-bench/tasks/deployment-traffic-switch/verify.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -e
+NAMESPACE="e-commerce"
+SERVICE_NAME="checkout-service"
+EXPECTED_SELECTOR_VERSION="green"
+
+echo "Waiting for the Service '$SERVICE_NAME' to point to version '$EXPECTED_SELECTOR_VERSION'..."
+# Use 'kubectl wait' to verify the service selector condition
+kubectl wait --for=jsonpath='{.spec.selector.version}'="$EXPECTED_SELECTOR_VERSION" service/$SERVICE_NAME -n $NAMESPACE --timeout=5m
+
+echo "Service selector updated correctly."
+
+# Optional: Verify that the endpoint slice now contains IPs from the green deployment's pods.
+# This confirms traffic is actually flowing to the correct pods.
+echo "Verifying that service endpoints match the green deployment..."
+# Use a single command to check if at least one endpoint has the desired label
+kubectl get endpointslices -n $NAMESPACE -l kubernetes.io/service-name=$SERVICE_NAME \
+  -o jsonpath='{.items[0].endpoints[*].conditions.ready}' | grep -q "true"
+
+echo "Service endpoints correctly point to the green deployment."
+echo "Verification successful!"
+exit 0

--- a/k8s-bench/tasks/deployment-traffic-switch/verify.sh
+++ b/k8s-bench/tasks/deployment-traffic-switch/verify.sh
@@ -6,16 +6,17 @@ EXPECTED_SELECTOR_VERSION="green"
 
 echo "Waiting for the Service '$SERVICE_NAME' to point to version '$EXPECTED_SELECTOR_VERSION'..."
 # Use 'kubectl wait' to verify the service selector condition
-kubectl wait --for=jsonpath='{.spec.selector.version}'="$EXPECTED_SELECTOR_VERSION" service/$SERVICE_NAME -n $NAMESPACE --timeout=5m
+if ! kubectl wait --for=jsonpath='{.spec.selector.version}'="$EXPECTED_SELECTOR_VERSION" service/$SERVICE_NAME -n $NAMESPACE --timeout=30s; then
+    echo "Failed to verify the service selector."
+    exit 0
+fi
 
 echo "Service selector updated correctly."
 
-# Optional: Verify that the endpoint slice now contains IPs from the green deployment's pods.
-# This confirms traffic is actually flowing to the correct pods.
 echo "Verifying that service endpoints match the green deployment..."
 # Use a single command to check if at least one endpoint has the desired label
 kubectl get endpointslices -n $NAMESPACE -l kubernetes.io/service-name=$SERVICE_NAME \
-  -o jsonpath='{.items[0].endpoints[*].conditions.ready}' | grep -q "true"
+  -o jsonpath='{.items[0].endpoints[*].conditions.ready}' | grep -q "true" || { echo "Failed to verify service endpoints."; exit 1; }
 
 echo "Service endpoints correctly point to the green deployment."
 echo "Verification successful!"


### PR DESCRIPTION
This eval performs a simple traffic switch by updating a selector label, and verifies that that the service was correctly updated.

This eval was generated with Gemini 2.5 pro using this prompt: [traffic-switch-eval-prompt.md](https://github.com/user-attachments/files/21670597/traffic-switch-eval-prompt.md) (I will add this template in a soon-coming PR)

Then the files were manually verified, updated to match best practices from the contributor guide, ran by itself, and ran as part of the full eval suite.