### PR TITLE
eval: Add canary deployment eval

### DIFF
--- a/k8s-bench/tasks/create-canary-deployment/artifacts/deployment-v1.yaml
+++ b/k8s-bench/tasks/create-canary-deployment/artifacts/deployment-v1.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: engine-v2-0
+  labels:
+    app: recommendation-engine
+    version: v2.0
+spec:
+  replicas: 10
+  selector:
+    matchLabels:
+      app: recommendation-engine
+      version: v2.0
+  template:
+    metadata:
+      labels:
+        app: recommendation-engine
+        version: v2.0
+    spec:
+      containers:
+      - name: rec-engine
+        image: nginx:1.28
+        ports:
+        - containerPort: 80

--- a/k8s-bench/tasks/create-canary-deployment/artifacts/service.yaml
+++ b/k8s-bench/tasks/create-canary-deployment/artifacts/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: recommendation-engine
+spec:
+  selector:
+    app: recommendation-engine
+    version: v2.0
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 80

--- a/k8s-bench/tasks/create-canary-deployment/cleanup.sh
+++ b/k8s-bench/tasks/create-canary-deployment/cleanup.sh
@@ -3,4 +3,4 @@ set -e
 NAMESPACE="canary-deployment-ns"
 
 # Delete the namespace
-kubectl delete namespace $NAMESPACE --wait=false
+kubectl delete namespace $NAMESPACE --wait=false --ignore-not-found

--- a/k8s-bench/tasks/create-canary-deployment/cleanup.sh
+++ b/k8s-bench/tasks/create-canary-deployment/cleanup.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+NAMESPACE="canary-deployment-ns"
+
+# Delete the namespace
+kubectl delete namespace $NAMESPACE --wait=false

--- a/k8s-bench/tasks/create-canary-deployment/setup.sh
+++ b/k8s-bench/tasks/create-canary-deployment/setup.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+NAMESPACE="canary-deployment-ns"
+
+# Create the namespace
+kubectl create namespace $NAMESPACE
+
+# Apply the initial stable deployment and the service pointing only to it
+kubectl apply -n $NAMESPACE -f artifacts/deployment-v1.yaml
+kubectl apply -n $NAMESPACE -f artifacts/service.yaml

--- a/k8s-bench/tasks/create-canary-deployment/task.yaml
+++ b/k8s-bench/tasks/create-canary-deployment/task.yaml
@@ -1,5 +1,5 @@
 script:
-  - prompt: "We want to test a new version of our recommendation engine (image tag 1.29) in production without disturbing the existing stable deployment. Can you deploy it as a canary (as engine-v2-1)? We want about 10% of traffic to go to the new version. The current deployment is named engine-v2-0 and has 10 replicas."
+  - prompt: "We want to test a new version of our recommendation engine (image tag 1.29) in production without disturbing the existing stable deployment. Can you deploy it as a canary (as engine-v2-1)? We want about 10% of traffic to go to the new version. The current deployment is named engine-v2-0."
 setup: "setup.sh"
 verifier: "verify.sh"
 cleanup: "cleanup.sh"

--- a/k8s-bench/tasks/create-canary-deployment/task.yaml
+++ b/k8s-bench/tasks/create-canary-deployment/task.yaml
@@ -1,0 +1,6 @@
+script:
+  - prompt: "We want to test a new version of our recommendation engine (image tag 1.29) in production without disturbing the existing stable deployment. Can you deploy it as a canary (as engine-v2-1)? We want about 10% of traffic to go to the new version. The current deployment is named engine-v2-0 and has 10 replicas."
+setup: "setup.sh"
+verifier: "verify.sh"
+cleanup: "cleanup.sh"
+difficulty: "hard"

--- a/k8s-bench/tasks/create-canary-deployment/verify.sh
+++ b/k8s-bench/tasks/create-canary-deployment/verify.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+# A more robust script header
+# exit on any error, exit on undeclared variable, and fail pipe commands on the first error
+set -euo pipefail
+
+# All variables are defined here for easy modification
+NAMESPACE="canary-deployment-ns"
+CANARY_DEPLOYMENT="engine-v2-1"
+STABLE_DEPLOYMENT="engine-v2-0"
+SERVICE="recommendation-engine"
+CANARY_IMAGE="nginx:1.29"
+CANARY_REPLICAS=1
+STABLE_REPLICAS=10
+EXPECTED_TOTAL_ENDPOINTS=$((CANARY_REPLICAS + STABLE_REPLICAS))
+TIMEOUT="30s"
+
+# Wait for both deployments to be available and fully rolled out
+if ! kubectl wait deployment "$CANARY_DEPLOYMENT" -n "$NAMESPACE" \
+  --for=condition=Available=true \
+  --timeout="$TIMEOUT"; then
+    echo "ERROR: Failed to find available canary deployment: '$CANARY_DEPLOYMENT'."
+    exit 1
+fi
+
+if ! kubectl wait deployment "$CANARY_DEPLOYMENT" -n "$NAMESPACE" \
+  --for=condition=Available=true \
+  --for=jsonpath="{.status.updatedReplicas}=${CANARY_REPLICAS}" \
+  --timeout="$TIMEOUT"; then
+
+    echo "ERROR: Canary deployment does not have the correct amount of replicas."
+    exit 1
+fi
+
+
+if ! kubectl wait deployment "$STABLE_DEPLOYMENT" -n "$NAMESPACE" \
+  --for=condition=Available=true \
+  --for=jsonpath="{.status.updatedReplicas}=${STABLE_REPLICAS}" \
+  --timeout="$TIMEOUT"; then
+
+    echo "ERROR: Stable deployment does not have the correct amount of replicas."
+    exit 1
+fi
+
+# Verify the canary deployment is using the correct container image
+CURRENT_CANARY_IMAGE=$(kubectl get deployment "$CANARY_DEPLOYMENT" -n "$NAMESPACE" -o jsonpath='{.spec.template.spec.containers[0].image}')
+if [[ "$CURRENT_CANARY_IMAGE" != "$CANARY_IMAGE" ]]; then
+  echo "ERROR: Canary deployment image is '$CURRENT_CANARY_IMAGE', expected '$CANARY_IMAGE'."
+  exit 1
+fi
+
+# Verify the service selector targets the general app label without a version
+SERVICE_JSON=$(kubectl get svc "$SERVICE" -n "$NAMESPACE" -o json)
+SELECTOR_APP=$(echo "$SERVICE_JSON" | jq -r '.spec.selector.app')
+# 'jq' will output the string 'null' if the key doesn't exist
+SELECTOR_VERSION=$(echo "$SERVICE_JSON" | jq -r '.spec.selector.version')
+
+if [[ "$SELECTOR_APP" != "$SERVICE" ]] || [[ "$SELECTOR_VERSION" != "null" ]]; then
+    echo "ERROR: Service selector is incorrect. It should only target 'app: $SERVICE'."
+    echo "   Found: app='$SELECTOR_APP', version='$SELECTOR_VERSION'"
+    exit 1
+fi
+
+# Wait until the service has endpoints for all pods (stable + canary) to confirm traffic is flowing to all expected pods
+echo "--> Waiting for service '$SERVICE' to have '$EXPECTED_TOTAL_ENDPOINTS' endpoints..."
+success=false
+# This loop will try 18 times, waiting 5 seconds between each attempt (90s total timeout)
+for i in {1..18}; do
+    # Using jq for a readable and robust way to count ready addresses.
+    count=$(kubectl get endpoints "$SERVICE" -n "$NAMESPACE" -o json 2>/dev/null | jq '([.subsets[].addresses // [] | length] | add) // 0' || echo 0)
+
+    if [[ "$count" -eq "$EXPECTED_TOTAL_ENDPOINTS" ]]; then
+        echo "Success: Service has all $count endpoints."
+        success=true
+        break
+    fi
+
+    echo "  ($i/18) Waiting... found $count endpoints. Retrying in 5 seconds..."
+    sleep 5
+done
+
+if ! $success; then
+    echo "ERROR: Timed out waiting for service endpoints."
+    echo "  Found $count endpoints, but expected $EXPECTED_TOTAL_ENDPOINTS."
+    exit 1
+fi
+
+
+echo "--- Verification Successful! ---"
+echo "Canary deployment is correctly configured and receiving traffic."
+exit 0


### PR DESCRIPTION
Adds an eval for creating a canary deployment with some stated requirements.
* This eval fails 80% or more of the time on Gemini 2.5 pro, due to small mistakes in correctness. Wrong deployment names, incorrect number of replicas, scaling down the stable deployment even though explicitly told not to. The overall task is relatively simple but since these small measure of correctness are important, and even gemini 2.5 pro keeps making mistakes on them, I'm marking it as hard.

Generated using the prompt in #471 with this added input:
```
Prompt: "We want to test a new version of our recommendation engine (image tag v1.29) in production. Can you deploy it as a canary? We want about 10% of traffic to go to the new version. The current deployment is named engine-v2-0 and has 10 replicas."

Verification: The agent must create a new Deployment named engine-v2-1 with the new image tag and 1 replica. It must ensure the Service selector is updated to select pods from both deployments, for example, by using a common label like app: recommendation-engine that is present on both sets of pods, while version-specific labels differentiate them.
```

Example of a successful run's output:
```
deployment.apps/engine-v2-1 condition met
deployment.apps/engine-v2-1 condition met
deployment.apps/engine-v2-0 condition met
--> Waiting for service 'recommendation-engine' to have '11' endpoints...
Success: Service has all 11 endpoints.
--- Verification Successful! ---
Canary deployment is correctly configured and receiving traffic.
```

Example of a failed run's output:
```
deployment.apps/engine-v2-1 condition met
deployment.apps/engine-v2-1 condition met
error: timed out waiting for the condition on deployments/engine-v2-0
ERROR: Stable deployment does not have the correct amount of replicas.
```