### PR TITLE
feat: Remove goodbye message, make `sessions` metaquery use table format

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -246,12 +246,10 @@ func main() {
 		}
 		// Exit with non-zero status code on error, unless it's a graceful shutdown.
 		if errors.Is(err, context.Canceled) {
-			fmt.Fprintln(os.Stderr, "\nGoodbye!")
 			os.Exit(0)
 		}
 		os.Exit(1)
 	}
-	fmt.Fprintln(os.Stderr, "Goodbye!")
 }
 
 func run(ctx context.Context) error {

--- a/pkg/agent/conversation.go
+++ b/pkg/agent/conversation.go
@@ -703,29 +703,37 @@ func (c *Agent) handleMetaQuery(ctx context.Context, query string) (answer strin
 		if err != nil {
 			return "", false, fmt.Errorf("failed to create session manager: %w", err)
 		}
+
 		sessionList, err := manager.ListSessions()
 		if err != nil {
 			return "", false, fmt.Errorf("failed to list sessions: %w", err)
 		}
 		if len(sessionList) == 0 {
-			return "No sessions found", true, nil
+			return "No sessions found.", true, nil
 		}
-		availableSessions := "Available sessions:\n\n"
+
+		// Add ```text so markdown doesn't wreck the format
+		availableSessions := "```text"
+		availableSessions += "Available sessions:\n\n"
+		availableSessions += "ID\t\t\tCreated\t\t\tLast Accessed\t\tModel\t\tProvider\n"
+		availableSessions += "--\t\t\t-------\t\t\t-------------\t\t-----\t\t--------\n"
+
 		for _, session := range sessionList {
 			metadata, err := session.LoadMetadata()
 			if err != nil {
-				fmt.Printf("%s\t\t<error loading metadata>\n", session.ID)
+				availableSessions += fmt.Sprintf("%s\t\t<error loading metadata>\n", session.ID)
 				continue
 			}
 
-			availableSessions += fmt.Sprintf("ID: %s\nCreated: %s\nLast Accessed: %s\nModel: %s\nProvider: %s\n\n",
+			availableSessions += fmt.Sprintf("%s\t%s\t%s\t%s\t%s\n",
 				session.ID,
-				metadata.CreatedAt.Format("2006-01-02 15:04:05"),
-				metadata.LastAccessed.Format("2006-01-02 15:04:05"),
+				metadata.CreatedAt.Format("2006-01-02 15:04"),
+				metadata.LastAccessed.Format("2006-01-02 15:04"),
 				metadata.ModelID,
 				metadata.ProviderID)
 		}
-
+		// close the ```text box
+		availableSessions += "```"
 		return availableSessions, true, nil
 	}
 


### PR DESCRIPTION
* Removes goodbye message since it seems out of place to close every interaction (including metaqueries)
* Makes `session` metaquery use table format instead of the previous stacked format. example:
<img width="961" height="235" alt="image" src="https://github.com/user-attachments/assets/904c49b7-caee-4ac2-9d8d-7cf7bc12c17a" />
