### PR TITLE
chore: ignore .air.toml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ dist/
 
 # Ignore generated credentials from google-github-actions/auth
 gha-creds-*.json
+
+# air config
+.air.toml


### PR DESCRIPTION
I have been using `air` to rebuild/reload and found it useful especially while iterating on the web interface. Adding the air toml to gitignore.