### PR TITLE
feat: Add resume-session to metaquery handling

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -416,18 +416,6 @@ func RunRootCommand(ctx context.Context, opt Options, args []string) error {
 				if err != nil {
 					return fmt.Errorf("failed to get latest session: %w", err)
 				}
-				if chatStore == nil {
-					// No sessions exist, create a new one
-					meta := sessions.Metadata{
-						ProviderID: opt.ProviderID,
-						ModelID:    opt.ModelID,
-					}
-					chatStore, err = sessionManager.NewSession(meta)
-					if err != nil {
-						return fmt.Errorf("failed to create new session: %w", err)
-					}
-					klog.Infof("Created new session: %s\n", chatStore.(*sessions.Session).ID)
-				}
 			} else {
 				sessionID = opt.ResumeSession
 				chatStore, err = sessionManager.FindSessionByID(sessionID)

--- a/pkg/agent/conversation.go
+++ b/pkg/agent/conversation.go
@@ -200,13 +200,7 @@ func (s *Agent) Init(ctx context.Context) error {
 	}
 
 	if session, ok := s.ChatMessageStore.(*sessions.Session); ok {
-		metadata, err := session.LoadMetadata()
-		if err != nil {
-			return fmt.Errorf("failed to load session metadata: %w", err)
-		}
-		s.session.ID = session.ID
-		s.session.CreatedAt = metadata.CreatedAt
-		s.session.LastModified = metadata.LastAccessed
+		s.loadSession(session.ID)
 	} else {
 		s.session.ID = uuid.New().String()
 		s.session.CreatedAt = time.Now()
@@ -747,36 +741,62 @@ func (c *Agent) handleMetaQuery(ctx context.Context, query string) (answer strin
 			return "Invalid command. Usage: resume-session <session_id>", true, nil
 		}
 		sessionID := parts[1]
-
-		manager, err := sessions.NewSessionManager()
-		if err != nil {
-			return "", false, fmt.Errorf("failed to create session manager: %w", err)
+		if err := c.loadSession(sessionID); err != nil {
+			return "", false, err
 		}
-
-		session, err := manager.FindSessionByID(sessionID)
-		if err != nil {
-			return "", false, fmt.Errorf("failed to get session: %w", err)
-		}
-
-		c.sessionMu.Lock()
-		c.ChatMessageStore = session
-		c.session.ChatMessageStore = session
-		c.session.Messages = session.ChatMessages()
-		metadata, err := session.LoadMetadata()
-		if err != nil {
-			c.sessionMu.Unlock()
-			return "", false, fmt.Errorf("failed to load session metadata: %w", err)
-		}
-		c.session.ID = session.ID
-		c.session.CreatedAt = metadata.CreatedAt
-		c.session.LastModified = metadata.LastAccessed
-		c.llmChat.Initialize(c.session.ChatMessageStore.ChatMessages())
-		c.sessionMu.Unlock()
-
 		return fmt.Sprintf("Resumed session %s.", sessionID), true, nil
 	}
 
 	return "", false, nil
+}
+
+// loadSession loads a session by ID (or latest), updates the agent's state, and re-initializes the chat.
+func (c *Agent) loadSession(sessionID string) error {
+	manager, err := sessions.NewSessionManager()
+	if err != nil {
+		return fmt.Errorf("failed to create session manager: %w", err)
+	}
+
+	var session *sessions.Session
+	if sessionID == "" || sessionID == "latest" {
+		s, err := manager.GetLatestSession()
+		if err != nil {
+			return fmt.Errorf("failed to get latest session: %w", err)
+		}
+		if s == nil {
+			// This can happen if GetLatestSession returns nil, nil (no sessions exist)
+			return fmt.Errorf("no sessions found to resume")
+		}
+		session = s
+	} else {
+		s, err := manager.FindSessionByID(sessionID)
+		if err != nil {
+			return fmt.Errorf("failed to get session %q: %w", sessionID, err)
+		}
+		session = s
+	}
+
+	c.sessionMu.Lock()
+	defer c.sessionMu.Unlock()
+
+	c.ChatMessageStore = session
+	c.session.ChatMessageStore = session
+	c.session.Messages = session.ChatMessages()
+	metadata, err := session.LoadMetadata()
+	if err != nil {
+		return fmt.Errorf("failed to load session metadata: %w", err)
+	}
+	c.session.ID = session.ID
+	c.session.CreatedAt = metadata.CreatedAt
+	c.session.LastModified = metadata.LastAccessed
+
+	if c.llmChat != nil {
+		if err := c.llmChat.Initialize(c.session.ChatMessageStore.ChatMessages()); err != nil {
+			return fmt.Errorf("failed to re-initialize chat with new session: %w", err)
+		}
+	}
+
+	return nil
 }
 
 func (c *Agent) listModels(ctx context.Context) ([]string, error) {


### PR DESCRIPTION
Adds "resume-session <session ID>" to metaquery handling.

demo (start from no session, load one session, load another session): https://github.com/user-attachments/assets/8ceca555-ab60-482a-8d81-e75074c437ab

demo (changing sessions in web ui): https://github.com/user-attachments/assets/49c4dd48-d13e-43e6-835f-c19d1421c9cf

