### PR TITLE
feat: Add save-session metaquery and ask to save on exit

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -464,6 +464,7 @@ func RunRootCommand(ctx context.Context, opt Options, args []string) error {
 
 	k8sAgent := &agent.Agent{
 		Model:              opt.ModelID,
+		Provider:           opt.ProviderID,
 		Kubeconfig:         opt.KubeConfigPath,
 		LLM:                llmClient,
 		MaxIterations:      opt.MaxIterations,

--- a/pkg/agent/conversation.go
+++ b/pkg/agent/conversation.go
@@ -355,24 +355,6 @@ func (c *Agent) Run(ctx context.Context, initialQuery string) error {
 					log.Info("Received input from channel", "userInput", userInput)
 					if userInput == io.EOF {
 						log.Info("Agent loop done, EOF received")
-						if _, ok := c.ChatMessageStore.(*sessions.InMemoryChatStore); ok {
-							c.addMessage(api.MessageSourceAgent, api.MessageTypeText, "Save session before quitting? (y/n)")
-							c.addMessage(api.MessageSourceAgent, api.MessageTypeUserInputRequest, ">>>")
-							response := <-c.Input
-							resp, ok := response.(*api.UserInputResponse)
-							if ok {
-								if resp.Query == "y" || resp.Query == "yes" {
-									sessionID, err := c.SaveSession()
-									if err != nil {
-										log.Error(err, "error saving session")
-									} else {
-										c.addMessage(api.MessageSourceAgent, api.MessageTypeText, "Session saved as "+sessionID)
-									}
-								} else {
-									c.addMessage(api.MessageSourceAgent, api.MessageTypeText, "Quitting without saving session.")
-								}
-							}
-						}
 						c.setAgentState(api.AgentStateExited)
 						return
 					}

--- a/pkg/agent/conversation.go
+++ b/pkg/agent/conversation.go
@@ -765,7 +765,7 @@ func (c *Agent) SaveSession() (string, error) {
 		return foundSession.ID, nil
 	}
 	metadata := sessions.Metadata{
-		CreatedAt:    time.Now(),
+		CreatedAt:    c.session.CreatedAt,
 		LastAccessed: time.Now(),
 		ModelID:      c.Model,
 		ProviderID:   c.Provider,

--- a/pkg/agent/conversation.go
+++ b/pkg/agent/conversation.go
@@ -762,7 +762,7 @@ func (c *Agent) SaveSession() (string, error) {
 	}
 	foundSession, _ := manager.FindSessionByID(c.session.ID)
 	if foundSession != nil {
-		return "", fmt.Errorf("session with ID %s already exists", foundSession.ID)
+		return foundSession.ID, nil
 	}
 	metadata := sessions.Metadata{
 		CreatedAt:    time.Now(),

--- a/pkg/ui/terminal.go
+++ b/pkg/ui/terminal.go
@@ -29,6 +29,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubectl-ai/pkg/agent"
 	"github.com/GoogleCloudPlatform/kubectl-ai/pkg/api"
 	"github.com/GoogleCloudPlatform/kubectl-ai/pkg/journal"
+	"github.com/GoogleCloudPlatform/kubectl-ai/pkg/sessions"
 	"github.com/GoogleCloudPlatform/kubectl-ai/pkg/tools"
 	"github.com/charmbracelet/glamour"
 	"github.com/chzyer/readline"
@@ -232,6 +233,26 @@ func (u *TerminalUI) Close() error {
 	return errors.Join(errs...)
 }
 
+// handleExit handles the logic for exiting the application, including prompting to save the session.
+// It takes a readLineFunc to abstract the input method (readline or tty).
+func (u *TerminalUI) handleExit(readLineFunc func(prompt string) (string, error)) {
+	if _, ok := u.agent.ChatMessageStore.(*sessions.InMemoryChatStore); ok {
+		answer, err := readLineFunc("Save session before quitting? (y/n) ")
+		if err != nil {
+			// This happens on Ctrl+C or Ctrl+D during the save prompt
+			fmt.Println("\nQuitting without saving session.")
+		} else {
+			answer = strings.TrimSpace(strings.ToLower(answer))
+			if answer == "y" || answer == "yes" {
+				u.agent.Input <- &api.UserInputResponse{Query: "save-session"}
+			} else {
+				fmt.Println("Quitting without saving session.")
+			}
+		}
+	}
+	u.agent.Input <- io.EOF
+}
+
 func (u *TerminalUI) handleMessage(msg *api.Message) {
 	text := ""
 	var styleOptions []styleOption
@@ -288,6 +309,13 @@ func (u *TerminalUI) handleMessage(msg *api.Message) {
 				fmt.Print("\n>>> ") // Print prompt manually
 				query, err = tReader.ReadString('\n')
 				if err != nil {
+					if err == io.EOF {
+						u.handleExit(func(prompt string) (string, error) {
+							fmt.Print("\n" + prompt)
+							return tReader.ReadString('\n')
+						})
+						return // exit handleMessage
+					}
 					klog.Errorf("Error reading from TTY: %v", err)
 					u.agent.Input <- fmt.Errorf("error reading from TTY: %w", err)
 					return
@@ -313,10 +341,11 @@ func (u *TerminalUI) handleMessage(msg *api.Message) {
 				if err != nil {
 					klog.Infof("Readline error: %v", err)
 					switch err {
-					case readline.ErrInterrupt: // Handle Ctrl+C
-						u.agent.Input <- io.EOF
-					case io.EOF: // Handle Ctrl+D
-						u.agent.Input <- io.EOF
+					case readline.ErrInterrupt, io.EOF: // Handle Ctrl+C or Ctrl+D
+						u.handleExit(func(prompt string) (string, error) {
+							rlInstance.SetPrompt(prompt)
+							return rlInstance.Readline()
+						})
 					default:
 						u.agent.Input <- err
 					}


### PR DESCRIPTION
Lets people start without a persisted session and switch at any time with save-session
Also, adds a check on ctrl+c exit whether user wants to save the current in-memory session.

demo (shows use of save-session, yes on exit save, and no on exit save): https://github.com/user-attachments/assets/dccb62e9-3f48-4b7d-b897-ac1ea6cb23ba

