### PR TITLE
agent: ignore empty query

### DIFF
--- a/pkg/agent/conversation.go
+++ b/pkg/agent/conversation.go
@@ -362,6 +362,10 @@ func (c *Agent) Run(ctx context.Context, initialQuery string) error {
 						log.Error(nil, "Received unexpected input from channel", "userInput", userInput)
 						return
 					}
+					if strings.TrimSpace(query.Query) == "" {
+						log.Info("No query provided, skipping agentic loop")
+						continue
+					}
 					c.addMessage(api.MessageSourceUser, api.MessageTypeText, query.Query)
 					// we don't need the agentic loop for meta queries
 					// for ex. model, tools, etc.


### PR DESCRIPTION
With this PR, agent as well the terminal-ui will ignore empty user queries. Before this PR, we had a bug in the system where empty query will force the agent into an irrecoverable state where it will continue to make LLM request with empty query and keep on causing `400: invalid argument` LLM API error.

And it is easy to get in this state especially when you are waiting for LLM to respond and end up pressing <ENTER> with no input.

An example:
```
>>>
E0813 21:27:30.319436   66139 conversation.go:501] "error reading streaming LLM response" err=<
        Error 400, Message: * GenerateContentRequest.contents[157].parts[0].data: required oneof field 'data' must have one initialized field
        , Status: INVALID_ARGUMENT, Details: []
 >
E0813 21:27:30.319541   66139 conversation.go:538] "error streaming LLM response" err=<
        Error 400, Message: * GenerateContentRequest.contents[157].parts[0].data: required oneof field 'data' must have one initialized field
        , Status: INVALID_ARGUMENT, Details: []
 >
Error: Error 400, Message: * GenerateContentRequest.contents[157].parts[0].data: required oneof field 'data' must have one initialized field
```

I will cut another release once this gets merged.

/cc @noahlwest @ShubyM 