### PR TITLE
fix: don't return error on failed initialize

### DIFF
--- a/gollm/azopenai.go
+++ b/gollm/azopenai.go
@@ -271,7 +271,8 @@ func (c *AzureOpenAIChat) IsRetryableError(err error) bool {
 }
 
 func (c *AzureOpenAIChat) Initialize(messages []*api.Message) error {
-	return fmt.Errorf("Initialize not yet implemented for azopenai")
+	klog.Warning("chat history persistence is not supported for provider 'azopenai', using in-memory chat history")
+	return nil
 }
 
 func (c *AzureOpenAIChat) SendStreaming(ctx context.Context, contents ...any) (ChatResponseIterator, error) {

--- a/gollm/bedrock.go
+++ b/gollm/bedrock.go
@@ -146,7 +146,8 @@ type bedrockChat struct {
 }
 
 func (cs *bedrockChat) Initialize(history []*api.Message) error {
-	return fmt.Errorf("Initialize not yet implemented for bedrock")
+	klog.Warning("chat history persistence is not supported for provider 'bedrock', using in-memory chat history")
+	return nil
 }
 
 // Send sends a message to the chat and returns the response

--- a/gollm/grok.go
+++ b/gollm/grok.go
@@ -380,8 +380,9 @@ func (cs *grokChatSession) IsRetryableError(err error) bool {
 	return DefaultIsRetryableError(err)
 }
 
-func (cs *grokChatSession) Initialize(history []*api.Message) error {
-	return fmt.Errorf("LoadHistory not yet implemented for grok")
+func (cs *grokChatSession) Initialize(messages []*api.Message) error {
+	klog.Warning("chat history persistence is not supported for provider 'grok', using in-memory chat history")
+	return nil
 }
 
 // --- Helper structs for ChatResponse interface ---

--- a/gollm/llamacpp.go
+++ b/gollm/llamacpp.go
@@ -296,7 +296,8 @@ func (c *LlamaCppChat) IsRetryableError(err error) bool {
 }
 
 func (c *LlamaCppChat) Initialize(messages []*api.Message) error {
-	return fmt.Errorf("Initialize not yet implemented for llamacpp")
+	klog.Warning("chat history persistence is not supported for provider 'llamacpp', using in-memory chat history")
+	return nil
 }
 
 func ptrTo[T any](t T) *T {

--- a/gollm/ollama.go
+++ b/gollm/ollama.go
@@ -210,7 +210,8 @@ func (c *OllamaChat) SendStreaming(ctx context.Context, contents ...any) (ChatRe
 }
 
 func (c *OllamaChat) Initialize(messages []*kctlApi.Message) error {
-	return fmt.Errorf("Initialize not yet implemented for ollama")
+	klog.Warning("chat history persistence is not supported for provider 'ollama', using in-memory chat history")
+	return nil
 }
 
 type OllamaChatResponse struct {

--- a/gollm/openai.go
+++ b/gollm/openai.go
@@ -424,7 +424,8 @@ func (cs *openAIChatSession) IsRetryableError(err error) bool {
 }
 
 func (cs *openAIChatSession) Initialize(messages []*api.Message) error {
-	return fmt.Errorf("Initialize not yet implemented for openai")
+	klog.Warning("chat history persistence is not supported for provider 'openai', using in-memory chat history")
+	return nil
 }
 
 // Helper structs for ChatResponse interface


### PR DESCRIPTION
Right now any model that doesn't support session persistence (by way of Initialize() fn) will give an error on startup about not supporting session persistence. This will instead log the error and let the rest of the program run.

Tested this with ollama provider to make sure things continue to work with or without session flags