### PR TITLE
Fix Var reference for UI configuration for ui Type

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ removeWorkdir: false             # Remove temporary working directory after exec
 kubeconfig: "~/.kube/config"      # Path to kubeconfig file
 
 # UI configuration
-userInterface: "terminal"         # UI mode: "terminal" or "html"
+uiType: "terminal"                # UI mode: "terminal" or "web"
 uiListenAddress: "localhost:8888" # Address for HTML UI server
 
 # Prompt configuration


### PR DESCRIPTION
This fixes the reference var in the main README for ui config type.

To add to this: I found in code that there is a TUI type too, but as it is not working as it should (tested on Mac and for every input you get a weird string in the user input box) I haven't advertised it in the README. 