### PR TITLE
feat: make installation directory configurable via INSTALL_DIR env var

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -113,8 +113,9 @@ trap cleanup EXIT INT TERM
     exit 1
   fi
 
-  echo "Installing $BINARY to /usr/local/bin (may require sudo)..."
-  sudo install -m 0755 "$BINARY" /usr/local/bin/
+  INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
+  echo "Installing $BINARY to $INSTALL_DIR (may require sudo)..."
+  sudo install -m 0755 "$BINARY" "$INSTALL_DIR/"
 )
 
 echo "✅ $BINARY installed successfully! Run '$BINARY --help' to get started."


### PR DESCRIPTION
- Allow the installation directory to be customized using the INSTALL_DIR environment variable
- Update installation message to reflect the configurable target directory

1. Make sure you have write permission to $INSTALL_DIR, or use sudo if necessary.
2. If $INSTALL_DIR does not exist, the install command will attempt to create it, but this may require elevated privileges.
3. If installing to a directory not in $PATH, you must reference the full path to use the binary or add it to your $PATH manually.