### PR TITLE
feat: always ask for approval for non-readonly commands

### DIFF
--- a/pkg/agent/conversation.go
+++ b/pkg/agent/conversation.go
@@ -931,13 +931,7 @@ func (c *Agent) analyzeToolCalls(ctx context.Context, toolCalls []gollm.Function
 		if err != nil {
 			toolCallAnalysis[i].IsInteractiveError = err
 		}
-		modifiesResourceStr := toolCall.GetTool().CheckModifiesResource(call.Arguments)
-		if modifiesResourceStr == "unknown" {
-			if llmModifies, ok := call.Arguments["modifies_resource"].(string); ok {
-				modifiesResourceStr = llmModifies
-			}
-		}
-		toolCallAnalysis[i].ModifiesResourceStr = modifiesResourceStr
+		toolCallAnalysis[i].ModifiesResourceStr = toolCall.GetTool().CheckModifiesResource(call.Arguments)
 		toolCallAnalysis[i].ParsedToolCall = toolCall
 	}
 	return toolCallAnalysis, nil


### PR DESCRIPTION
Two big changes related to command approval flow.

- Do not rely on LLM to determine if a command modifies resource or not.
- If LLM suggests a composite command such as `kubectl get pods | wc -l` or generic bash script command multiple commands, we will always ask for approval even if the kubectl commands are readonly (this is to avoid exfilteration attacks).

## Why
We are seeing requests for using the tool against production clusters and without the above changes, I see a serious risk of prompt injection attacks.

It may appear that the above changes may cause `prompt fatigue` because it will ask the user to approve commands but majority of the use-cases involves read-only kubectl commands and our current static filter will cover those pretty well and not request user to approve those commands.

## Follow ups (coming)
 - Remove the "modifies_resource" parameter in the LLM call completely.
 - Improve the system prompt to steer LLM to avoid using composite calls as much as possible when using kubectl.

fixes https://github.com/GoogleCloudPlatform/kubectl-ai/issues/449


<img width="1209" height="1110" alt="image" src="https://github.com/user-attachments/assets/3523c6af-e4ab-43e5-9aa5-2ec07307dffb" />

 