### PR TITLE
fix: GetLatestSession() does not get latest session

### DIFF
--- a/pkg/agent/conversation.go
+++ b/pkg/agent/conversation.go
@@ -831,8 +831,9 @@ func (c *Agent) loadSession(sessionID string) error {
 	}
 	c.session.ID = session.ID
 	c.session.CreatedAt = metadata.CreatedAt
-	c.session.LastModified = time.Now()
-	metadata.LastAccessed = time.Now()
+	now := time.Now()
+	c.session.LastModified = now
+	metadata.LastAccessed = now
 	if err := session.SaveMetadata(metadata); err != nil {
 		return fmt.Errorf("failed to update session metadata: %w", err)
 	}

--- a/pkg/sessions/manager.go
+++ b/pkg/sessions/manager.go
@@ -21,6 +21,8 @@ import (
 	"path/filepath"
 	"sort"
 	"time"
+
+	"k8s.io/klog/v2"
 )
 
 const (
@@ -119,7 +121,7 @@ func (sm *SessionManager) GetLatestSession() (*Session, error) {
 		meta, err := s.LoadMetadata()
 		if err != nil {
 			// Warn in case a metadata is corrupted
-			fmt.Printf("warn: could not load metadata for session %s: %v\n", s.ID, err)
+			klog.Warningf("could not load metadata for session %s: %v", s.ID, err)
 			continue
 		}
 		if latestSession == nil || meta.LastAccessed.After(latestTime) {


### PR DESCRIPTION
Fixes #518

`GetLatestSession()` now checks the session metadata instead of relying on sorting by name. This also allows us to have named sessions, importing sessions, etc. and still get the latest. Also updates LastAccessed time when a session is loaded (for example, with resume-session during a chat.)

Since the session metadata is stored on the filesystem, GetLatestSession now has to read from the filesystem. If this is too slow or too expensive, we can consider alternatives.