### PR TITLE
fix: make multi-container-pod-communication eval less flaky

### DIFF
--- a/k8s-bench/tasks/multi-container-pod-communication/task.yaml
+++ b/k8s-bench/tasks/multi-container-pod-communication/task.yaml
@@ -1,6 +1,11 @@
 script:
 - prompt: |
-    In the multi-container-test namespace, run a pod called communication-pod with two containers: a web server that serves traffic and writes logs, and a logger that processes those logs from a shared volume. The logger should only start once the web server is ready. The pod should be considered ready when the web server is serving traffic.
+    In the multi-container-logging namespace, run a pod called communication-pod with two containers:
+    1. A 'web-server' nginx instance that serves traffic
+    2. A 'logger' busybox instance that processes those logs from a shared volume, 'logs-volume' with 'tail -f /var/log/nginx/access.log'
+
+    Both containers should mount logs-volume at '/var/log/nginx'.
+    The logger should only start once the web server is ready. The pod should be considered ready when the web server is serving traffic.
 setup: "setup.sh"
 verifier: "verify.sh"
 cleanup: "cleanup.sh"

--- a/k8s-bench/tasks/multi-container-pod-communication/verify.sh
+++ b/k8s-bench/tasks/multi-container-pod-communication/verify.sh
@@ -1,26 +1,29 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
+
+NAMESPACE="multi-container-logging"
+POD_NAME="communication-pod"
 
 # Wait for pod to be running
-echo "Waiting for communication-pod to be ready..."
-if ! kubectl wait --for=condition=Ready pod/communication-pod -n multi-container-test --timeout=60s; then
+echo "Waiting for pod '$POD_NAME' to be ready..."
+if ! kubectl wait --for=condition=Ready pod/$POD_NAME -n "$NAMESPACE" --timeout=60s; then
     echo "Pod failed to reach Ready state in time"
     echo "Current pod status:"
-    kubectl describe pod communication-pod -n multi-container-test
+    kubectl describe pod "$POD_NAME" -n "$NAMESPACE"
     exit 1
 fi
 
 echo "Pod is ready. Verifying configuration..."
 
 # then verify that both containers are running
-CONTAINERS=$(kubectl get pod communication-pod -n multi-container-test -o jsonpath='{.spec.containers[*].name}')
-if [[ ! "$CONTAINERS" == *"web"* ]] || [[ ! "$CONTAINERS" == *"logger"* ]]; then
-    echo "Pod does not have both 'web' and 'logger' containers"
+CONTAINERS=$(kubectl get pod "$POD_NAME" -n "$NAMESPACE" -o jsonpath='{.spec.containers[*].name}')
+if [[ ! "$CONTAINERS" == *"web-server"* ]] || [[ ! "$CONTAINERS" == *"logger"* ]]; then
+    echo "Pod does not have both 'web-server' and 'logger' containers"
     exit 1
 fi
 
 # does the shared volume exists
-VOLUMES=$(kubectl get pod communication-pod -n multi-container-test -o jsonpath='{.spec.volumes[*].name}')
+VOLUMES=$(kubectl get pod "$POD_NAME" -n "$NAMESPACE" -o jsonpath='{.spec.volumes[*].name}')
 if [[ ! "$VOLUMES" == *"logs-volume"* ]]; then
     echo "Pod does not have the required 'logs-volume' volume"
     exit 1
@@ -28,11 +31,11 @@ fi
 
 # is web server accessible
 echo "Testing web server access..."
-kubectl exec communication-pod -n multi-container-test -c web -- curl -s -o /dev/null -w "%{http_code}" localhost:80 | grep -q 200
+kubectl exec "$POD_NAME" -n "$NAMESPACE" -c web-server -- curl -s -o /dev/null -w "%{http_code}" localhost:80 | grep -q 200
 
 # logger container can see the access logs
 echo "Verifying logger container can access nginx logs..."
-kubectl exec communication-pod -n multi-container-test -c logger -- ls -la /var/log/nginx/access.log
+kubectl exec "$POD_NAME" -n "$NAMESPACE" -c logger -- ls -la /var/log/nginx/access.log
 
 echo "All verification checks passed!"
 exit 0


### PR DESCRIPTION
This eval relied on the LLM to make multiple correct guesses, else it would fail. 

I've made the prompt more explicit about what we want, also did a slight refactor to bring this eval closer to our best practices.

Example of a successful run on gemini:

```
Running verifier for task multi-container-pod-communication

Running command: .../kubectl-ai/k8s-bench/tasks/multi-container-pod-communication/verify.sh
Waiting for pod 'communication-pod' to be ready...
pod/communication-pod condition met
Pod is ready. Verifying configuration...
Testing web server access...
Verifying logger container can access nginx logs...
-rw-r--r--    1 root     root           185 Sep  9 19:23 /var/log/nginx/access.log
All verification checks passed!

Running command: .../kubectl-ai/k8s-bench/tasks/multi-container-pod-communication/cleanup.sh
namespace "multi-container-test" deleted

Evaluation Results:
==================

Task: multi-container-pod-communication
  LLM Config: {ID:shim_disabled-gemini-gemini-2.5-pro ProviderID:gemini ModelID:gemini-2.5-pro EnableToolUseShim:false Quiet:true}
    success
```