### PR TITLE
fix: address statefulset-lifecycle and list-images-for-pods consistent failures

### DIFF
--- a/k8s-bench/tasks/list-images-for-pods/artifacts/Makefile
+++ b/k8s-bench/tasks/list-images-for-pods/artifacts/Makefile
@@ -1,6 +1,7 @@
 .PHONY: manifest
 manifest:
+	helm repo add bitnami https://charts.bitnami.com/bitnami
 	helm template \
-  		mysql oci://registry-1.docker.io/bitnamicharts/mysql --version 12.3.1 \
+  		mysql oci://registry-1.docker.io/bitnamicharts/mysql --version 9.10.4 \
   		--namespace list-images-for-pods \
   		--create-namespace > manifest.yaml

--- a/k8s-bench/tasks/list-images-for-pods/artifacts/manifest.yaml
+++ b/k8s-bench/tasks/list-images-for-pods/artifacts/manifest.yaml
@@ -1,58 +1,4 @@
 ---
-# Source: mysql/templates/networkpolicy.yaml
-kind: NetworkPolicy
-apiVersion: networking.k8s.io/v1
-metadata:
-  name: mysql
-  namespace: "list-images-for-pods"
-  labels:
-    app.kubernetes.io/instance: mysql
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: mysql
-    app.kubernetes.io/version: 8.4.4
-    helm.sh/chart: mysql-12.3.1
-    app.kubernetes.io/part-of: mysql
-spec:
-  podSelector:
-    matchLabels:
-      app.kubernetes.io/instance: mysql
-      app.kubernetes.io/managed-by: Helm
-      app.kubernetes.io/name: mysql
-      app.kubernetes.io/version: 8.4.4
-      helm.sh/chart: mysql-12.3.1
-  policyTypes:
-    - Ingress
-    - Egress
-  egress:
-    - {}
-  ingress:
-    # Allow connection from other cluster pods
-    - ports:
-        - port: 3306
----
-# Source: mysql/templates/primary/pdb.yaml
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: mysql
-  namespace: "list-images-for-pods"
-  labels:
-    app.kubernetes.io/instance: mysql
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: mysql
-    app.kubernetes.io/version: 8.4.4
-    helm.sh/chart: mysql-12.3.1
-    app.kubernetes.io/part-of: mysql
-    app.kubernetes.io/component: primary
-spec:
-  maxUnavailable: 1
-  selector:
-    matchLabels:
-      app.kubernetes.io/instance: mysql
-      app.kubernetes.io/name: mysql
-      app.kubernetes.io/part-of: mysql
-      app.kubernetes.io/component: primary
----
 # Source: mysql/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -60,13 +6,12 @@ metadata:
   name: mysql
   namespace: "list-images-for-pods"
   labels:
+    app.kubernetes.io/name: mysql
+    helm.sh/chart: mysql-9.10.4
     app.kubernetes.io/instance: mysql
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: mysql
-    app.kubernetes.io/version: 8.4.4
-    helm.sh/chart: mysql-12.3.1
-    app.kubernetes.io/part-of: mysql
-automountServiceAccountToken: false
+  annotations:
+automountServiceAccountToken: true
 secrets:
   - name: mysql
 ---
@@ -77,16 +22,14 @@ metadata:
   name: mysql
   namespace: "list-images-for-pods"
   labels:
+    app.kubernetes.io/name: mysql
+    helm.sh/chart: mysql-9.10.4
     app.kubernetes.io/instance: mysql
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: mysql
-    app.kubernetes.io/version: 8.4.4
-    helm.sh/chart: mysql-12.3.1
-    app.kubernetes.io/part-of: mysql
 type: Opaque
 data:
-  mysql-root-password: "R0tkcW9jS1hxTA=="
-  mysql-password: "bUZyN0pnUnVrbQ=="
+  mysql-root-password: "S1VKd0hBOGRJcg=="
+  mysql-password: "SEVYemFxTnFYcQ=="
 ---
 # Source: mysql/templates/primary/configmap.yaml
 apiVersion: v1
@@ -95,24 +38,20 @@ metadata:
   name: mysql
   namespace: "list-images-for-pods"
   labels:
+    app.kubernetes.io/name: mysql
+    helm.sh/chart: mysql-9.10.4
     app.kubernetes.io/instance: mysql
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: mysql
-    app.kubernetes.io/version: 8.4.4
-    helm.sh/chart: mysql-12.3.1
-    app.kubernetes.io/part-of: mysql
     app.kubernetes.io/component: primary
 data:
   my.cnf: |-
     [mysqld]
-    authentication_policy='* ,,'
+    default_authentication_plugin=mysql_native_password
     skip-name-resolve
     explicit_defaults_for_timestamp
     basedir=/opt/bitnami/mysql
     plugin_dir=/opt/bitnami/mysql/lib/plugin
     port=3306
-    mysqlx=0
-    mysqlx_port=33060
     socket=/opt/bitnami/mysql/tmp/mysql.sock
     datadir=/bitnami/mysql/data
     tmpdir=/opt/bitnami/mysql/tmp
@@ -121,6 +60,7 @@ data:
     pid-file=/opt/bitnami/mysql/tmp/mysqld.pid
     log-error=/opt/bitnami/mysql/logs/mysqld.log
     character-set-server=UTF8
+    collation-server=utf8_general_ci
     slow_query_log=0
     long_query_time=10.0
     
@@ -142,12 +82,10 @@ metadata:
   name: mysql-headless
   namespace: "list-images-for-pods"
   labels:
+    app.kubernetes.io/name: mysql
+    helm.sh/chart: mysql-9.10.4
     app.kubernetes.io/instance: mysql
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: mysql
-    app.kubernetes.io/version: 8.4.4
-    helm.sh/chart: mysql-12.3.1
-    app.kubernetes.io/part-of: mysql
     app.kubernetes.io/component: primary
 spec:
   type: ClusterIP
@@ -157,9 +95,9 @@ spec:
     - name: mysql
       port: 3306
       targetPort: mysql
-  selector:
-    app.kubernetes.io/instance: mysql
+  selector: 
     app.kubernetes.io/name: mysql
+    app.kubernetes.io/instance: mysql
     app.kubernetes.io/component: primary
 ---
 # Source: mysql/templates/primary/svc.yaml
@@ -169,13 +107,12 @@ metadata:
   name: mysql
   namespace: "list-images-for-pods"
   labels:
+    app.kubernetes.io/name: mysql
+    helm.sh/chart: mysql-9.10.4
     app.kubernetes.io/instance: mysql
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: mysql
-    app.kubernetes.io/version: 8.4.4
-    helm.sh/chart: mysql-12.3.1
-    app.kubernetes.io/part-of: mysql
     app.kubernetes.io/component: primary
+  annotations:
 spec:
   type: ClusterIP
   sessionAffinity: None
@@ -185,10 +122,9 @@ spec:
       protocol: TCP
       targetPort: mysql
       nodePort: null
-  selector:
-    app.kubernetes.io/instance: mysql
+  selector: 
     app.kubernetes.io/name: mysql
-    app.kubernetes.io/part-of: mysql
+    app.kubernetes.io/instance: mysql
     app.kubernetes.io/component: primary
 ---
 # Source: mysql/templates/primary/statefulset.yaml
@@ -198,41 +134,35 @@ metadata:
   name: mysql
   namespace: "list-images-for-pods"
   labels:
+    app.kubernetes.io/name: mysql
+    helm.sh/chart: mysql-9.10.4
     app.kubernetes.io/instance: mysql
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: mysql
-    app.kubernetes.io/version: 8.4.4
-    helm.sh/chart: mysql-12.3.1
-    app.kubernetes.io/part-of: mysql
     app.kubernetes.io/component: primary
 spec:
   replicas: 1
   podManagementPolicy: ""
   selector:
-    matchLabels:
-      app.kubernetes.io/instance: mysql
+    matchLabels: 
       app.kubernetes.io/name: mysql
-      app.kubernetes.io/part-of: mysql
+      app.kubernetes.io/instance: mysql
       app.kubernetes.io/component: primary
-  serviceName: mysql-headless
+  serviceName: mysql
   updateStrategy:
     type: RollingUpdate
   template:
     metadata:
       annotations:
-        checksum/configuration: b6d5ede247ae870aee299f83a08b81a91859c6c38996d11339e3a73cf6ed3bd4
+        checksum/configuration: 9a913d34b8851e10270d781b97f1c416b2ee2e320f39f98eb4ee23461c6b809c
       labels:
+        app.kubernetes.io/name: mysql
+        helm.sh/chart: mysql-9.10.4
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: mysql
-        app.kubernetes.io/version: 8.4.4
-        helm.sh/chart: mysql-12.3.1
-        app.kubernetes.io/part-of: mysql
         app.kubernetes.io/component: primary
     spec:
       serviceAccountName: mysql
       
-      automountServiceAccountToken: false
       affinity:
         podAffinity:
           
@@ -241,82 +171,30 @@ spec:
             - podAffinityTerm:
                 labelSelector:
                   matchLabels:
-                    app.kubernetes.io/instance: mysql
                     app.kubernetes.io/name: mysql
+                    app.kubernetes.io/instance: mysql
                 topologyKey: kubernetes.io/hostname
               weight: 1
         nodeAffinity:
           
       securityContext:
         fsGroup: 1001
-        fsGroupChangePolicy: Always
-        supplementalGroups: []
-        sysctls: []
       initContainers:
-        - name: preserve-logs-symlinks
-          image: docker.io/bitnami/mysql:8.4.4-debian-12-r4
-          imagePullPolicy: "IfNotPresent"
-          securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-              - ALL
-            readOnlyRootFilesystem: true
-            runAsGroup: 1001
-            runAsNonRoot: true
-            runAsUser: 1001
-            seLinuxOptions: {}
-            seccompProfile:
-              type: RuntimeDefault
-          resources:
-            limits:
-              cpu: 750m
-              ephemeral-storage: 2Gi
-              memory: 768Mi
-            requests:
-              cpu: 500m
-              ephemeral-storage: 50Mi
-              memory: 512Mi
-          command:
-            - /bin/bash
-          args:
-            - -ec
-            - |
-              #!/bin/bash
-
-              . /opt/bitnami/scripts/libfs.sh
-              # We copy the logs folder because it has symlinks to stdout and stderr
-              if ! is_dir_empty /opt/bitnami/mysql/logs; then
-                cp -r /opt/bitnami/mysql/logs /emptydir/app-logs-dir
-              fi
-          volumeMounts:
-            - name: empty-dir
-              mountPath: /emptydir
       containers:
         - name: mysql
-          image: docker.io/bitnami/mysql:8.4.4-debian-12-r4
+          image: docker.io/bitnami/mysql:8.0.33-debian-11-r17
           imagePullPolicy: "IfNotPresent"
           securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-              - ALL
-            readOnlyRootFilesystem: true
-            runAsGroup: 1001
             runAsNonRoot: true
             runAsUser: 1001
-            seLinuxOptions: {}
-            seccompProfile:
-              type: RuntimeDefault
           env:
             - name: BITNAMI_DEBUG
               value: "false"
-            - name: MYSQL_ROOT_PASSWORD_FILE
-              value: /opt/bitnami/mysql/secrets/mysql-root-password
-            - name: MYSQL_ENABLE_SSL
-              value: "no"
-            - name: MYSQL_PORT
-              value: "3306"
+            - name: MYSQL_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: mysql
+                  key: mysql-root-password
             - name: MYSQL_DATABASE
               value: "my_database"
           envFrom:
@@ -354,7 +232,7 @@ spec:
                   if [[ -f "${MYSQL_ROOT_PASSWORD_FILE:-}" ]]; then
                       password_aux=$(cat "$MYSQL_ROOT_PASSWORD_FILE")
                   fi
-                  mysqladmin ping -uroot -p"${password_aux}" | grep "mysqld is alive"
+                  mysqladmin status -uroot -p"${password_aux}"
           startupProbe:
             failureThreshold: 10
             initialDelaySeconds: 15
@@ -370,57 +248,28 @@ spec:
                   if [[ -f "${MYSQL_ROOT_PASSWORD_FILE:-}" ]]; then
                       password_aux=$(cat "$MYSQL_ROOT_PASSWORD_FILE")
                   fi
-                  mysqladmin ping -uroot -p"${password_aux}" | grep "mysqld is alive"
-          resources:
-            limits:
-              cpu: 750m
-              ephemeral-storage: 2Gi
-              memory: 768Mi
-            requests:
-              cpu: 500m
-              ephemeral-storage: 50Mi
-              memory: 512Mi
+                  mysqladmin status -uroot -p"${password_aux}"
+          resources: 
+            limits: {}
+            requests: {}
           volumeMounts:
             - name: data
               mountPath: /bitnami/mysql
-            - name: empty-dir
-              mountPath: /tmp
-              subPath: tmp-dir
-            - name: empty-dir
-              mountPath: /opt/bitnami/mysql/conf
-              subPath: app-conf-dir
-            - name: empty-dir
-              mountPath: /opt/bitnami/mysql/tmp
-              subPath: app-tmp-dir
-            - name: empty-dir
-              mountPath: /opt/bitnami/mysql/logs
-              subPath: app-logs-dir
             - name: config
               mountPath: /opt/bitnami/mysql/conf/my.cnf
               subPath: my.cnf
-            - name: mysql-credentials
-              mountPath: /opt/bitnami/mysql/secrets/
       volumes:
         - name: config
           configMap:
             name: mysql
-        - name: mysql-credentials
-          secret:
-            secretName: mysql
-            items:
-              - key: mysql-root-password
-                path: mysql-root-password
-              - key: mysql-password
-                path: mysql-password
-        - name: empty-dir
-          emptyDir: {}
   volumeClaimTemplates:
     - metadata:
         name: data
-        labels:
-          app.kubernetes.io/instance: mysql
+        labels: 
           app.kubernetes.io/name: mysql
+          app.kubernetes.io/instance: mysql
           app.kubernetes.io/component: primary
+        annotations:
       spec:
         accessModes:
           - "ReadWriteOnce"

--- a/k8s-bench/tasks/list-images-for-pods/task.yaml
+++ b/k8s-bench/tasks/list-images-for-pods/task.yaml
@@ -1,7 +1,6 @@
 script:
 - prompt: "What images are my pods running?"
 setup: "setup.sh"
-verifier: "verify.sh"
 cleanup: "cleanup.sh"
 # disabled: true
 difficulty: "medium"

--- a/k8s-bench/tasks/list-images-for-pods/task.yaml
+++ b/k8s-bench/tasks/list-images-for-pods/task.yaml
@@ -6,4 +6,4 @@ cleanup: "cleanup.sh"
 # disabled: true
 difficulty: "medium"
 expect:
-- contains: "docker.io/bitnami/mysql:8.4.4-debian-12-r4"
+- contains: "docker.io/bitnami/mysql:8.0.33-debian-11-r17"

--- a/k8s-bench/tasks/list-images-for-pods/verify.sh
+++ b/k8s-bench/tasks/list-images-for-pods/verify.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-
-set -o errexit
-set -o nounset
-set -o pipefail
-
-NAMESPACE=list-images-for-pods
-

--- a/k8s-bench/tasks/statefulset-lifecycle/task.yaml
+++ b/k8s-bench/tasks/statefulset-lifecycle/task.yaml
@@ -1,5 +1,5 @@
 script:
-- prompt: "Deploy a 5-replica StatefulSet db in namespace statefulset-test (already available) with each pod mounting a 1Gi PVC at /data containing a test file. Scale back to 2, verifying pods db-0 and db-1 retain /data/test."
+- prompt: "Deploy a 5-replica StatefulSet db in namespace statefulset-test with each pod mounting a 1Gi PVC at /data containing a file `test` populated with the string `initial_data`. Then, scale back down to 2 replicas."
 setup: "setup.sh"
 verifier: "verify.sh"
 cleanup: "cleanup.sh"

--- a/k8s-bench/tasks/statefulset-lifecycle/verify.sh
+++ b/k8s-bench/tasks/statefulset-lifecycle/verify.sh
@@ -1,15 +1,37 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
-# Verify only db-0 and db-1 remain
+# --- Configuration ---
+NAMESPACE="statefulset-test"
+STS_NAME="db"
+EXPECTED_CONTENT="initial_data"
+
+# Verify correct number of replicas
+echo "Verifying StatefulSet replica count"
+replicas=$(kubectl get sts "${STS_NAME}" -n "${NAMESPACE}" -o jsonpath='{.spec.replicas}')
+if [[ "${replicas}" -ne 2 ]]; then
+  echo "Expected 2 replicas, but got $replicas"
+  exit 1
+fi
+echo "StatefulSet is scaled to 2 replicas"
+
+echo "Verifying old pods are deleted"
+# Wait for scale-down: 2 ready pods and deletion of old pods
+kubectl wait pod/db-2 pod/db-3 pod/db-4 -n statefulset-test --for=delete --timeout=120s
+echo "Old pods are deleted"
+
+# Verify db-0 and db-1 exist and have the correct data
 for pod in db-0 db-1; do
-  kubectl get pod "$pod" -n statefulset-test || exit 1
-  data=$(kubectl exec "$pod" -n statefulset-test -- cat /data/test)
-  if [[ "$data" != "test" ]]; then
+  if ! kubectl get pod "$pod" -n "${NAMESPACE}" &> /dev/null; then
+    echo "Pod $pod not found in namespace $NAMESPACE"
+    exit 1
+  fi
+
+  data=$(kubectl exec "$pod" -n "${NAMESPACE}" -- cat /data/test)
+  if [[ "$data" != "${EXPECTED_CONTENT}" ]]; then
     echo "Data missing or incorrect in $pod"
     exit 1
   fi
 done
-# Wait for scale-down: 2 ready pods and deletion of old pods
-kubectl wait pod/db-2 pod/db-3 pod/db-4 -n statefulset-test --for=delete --timeout=120s
 
 exit 0


### PR DESCRIPTION
These two evals were failing consistently during my k8s-bench runs.

`statefulset-lifecycle` eval was relying on llm to guess things we verified, like the test file and its contents. I made the prompt and verification more specific so the llm can follow instructions instead of getting a lucky guess.

`list-images-for-pods` would time out every single time I tried to run it on a KinD cluster (my preferred cluster type for running evals). I pretty much just threw this problem at gemini, it suggested there was an issue with the given version of mysql running on local environments like kind or docker desktop, and suggested this older version as a fix. I updated the Makefile and rebuilt the manifest, and the eval no longer timed out on KinD or GKE clusters. Also removed unnecessary verify.sh for this eval