### PR TITLE
fix: eval hangs

### DIFF
--- a/k8s-bench/tasks/scale-down-deployment/setup.sh
+++ b/k8s-bench/tasks/scale-down-deployment/setup.sh
@@ -2,10 +2,10 @@
 # Create namespace and a deployment with initial replicas
 kubectl delete namespace scale-down-test --ignore-not-found
 kubectl create namespace scale-down-test
-kubectl create deployment web-service --image=nginx --replicas=4 -n scale-down-test
+kubectl create deployment web-service --image=nginx --replicas=2 -n scale-down-test
 # Wait for initial deployment to be ready
 for i in {1..30}; do
-    if kubectl get deployment web-service -n scale-down-test -o jsonpath='{.status.availableReplicas}' | grep -q "4"; then
+    if kubectl --request-timeout=10s get deployment web-service -n scale-down-test -o jsonpath='{.status.availableReplicas}' | grep -q "4"; then
         exit 0
     fi
     sleep 1

--- a/k8s-bench/tasks/scale-down-deployment/verify.sh
+++ b/k8s-bench/tasks/scale-down-deployment/verify.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
-# Wait for deployment to scale down to 2 replicas with kubectl wait
+# Wait for deployment to scale down to 1 replicas with kubectl wait
 if kubectl wait --for=condition=Available=True --timeout=30s deployment/web-service -n scale-down-test; then
-    # Verify the replica count is exactly 2
-    if [ "$(kubectl get deployment web-service -n scale-down-test -o jsonpath='{.status.availableReplicas}')" = "2" ]; then
+    # Verify the replica count is exactly 1
+    if [ "$(kubectl get deployment web-service -n scale-down-test -o jsonpath='{.status.availableReplicas}')" = "1" ]; then
         exit 0
     fi
 fi


### PR DESCRIPTION
Looking at the logs with timestamps: https://github.com/GoogleCloudPlatform/kubectl-ai/actions/runs/17626417909/job/50084327013#step:4:154
 
We always appear to hang when trying to see if there are 4 replicas present, so I put a timeout on the request and halved the number we make