### PR TITLE
update k8s-bench results

### DIFF
--- a/k8s-bench.json
+++ b/k8s-bench.json
@@ -24,23 +24,6 @@
     "error": ""
   },
   {
-    "name": "create-canary-deployment",
-    "llmConfig": {
-      "id": "shim_enabled-openai-google/gemma-3-27b-it",
-      "provider": "openai",
-      "model": "google/gemma-3-27b-it",
-      "enableToolUseShim": true,
-      "quiet": true
-    },
-    "result": "fail",
-    "failures": [
-      {
-        "message": "verifier script failed"
-      }
-    ],
-    "error": ""
-  },
-  {
     "name": "create-network-policy",
     "llmConfig": {
       "id": "shim_disabled-gemini-gemini-2.5-flash",
@@ -64,23 +47,6 @@
       "provider": "gemini",
       "model": "gemini-2.5-pro",
       "enableToolUseShim": false,
-      "quiet": true
-    },
-    "result": "fail",
-    "failures": [
-      {
-        "message": "verifier script failed"
-      }
-    ],
-    "error": ""
-  },
-  {
-    "name": "create-network-policy",
-    "llmConfig": {
-      "id": "shim_enabled-openai-google/gemma-3-27b-it",
-      "provider": "openai",
-      "model": "google/gemma-3-27b-it",
-      "enableToolUseShim": true,
       "quiet": true
     },
     "result": "fail",
@@ -121,18 +87,6 @@
     "error": ""
   },
   {
-    "name": "create-pod",
-    "llmConfig": {
-      "id": "shim_enabled-openai-google/gemma-3-27b-it",
-      "provider": "openai",
-      "model": "google/gemma-3-27b-it",
-      "enableToolUseShim": true,
-      "quiet": true
-    },
-    "result": "success",
-    "error": ""
-  },
-  {
     "name": "create-pod-mount-configmaps",
     "llmConfig": {
       "id": "shim_disabled-gemini-gemini-2.5-flash",
@@ -157,23 +111,6 @@
     "error": ""
   },
   {
-    "name": "create-pod-mount-configmaps",
-    "llmConfig": {
-      "id": "shim_enabled-openai-google/gemma-3-27b-it",
-      "provider": "openai",
-      "model": "google/gemma-3-27b-it",
-      "enableToolUseShim": true,
-      "quiet": true
-    },
-    "result": "fail",
-    "failures": [
-      {
-        "message": "verifier script failed"
-      }
-    ],
-    "error": ""
-  },
-  {
     "name": "create-pod-resources-limits",
     "llmConfig": {
       "id": "shim_disabled-gemini-gemini-2.5-flash",
@@ -192,18 +129,6 @@
       "provider": "gemini",
       "model": "gemini-2.5-pro",
       "enableToolUseShim": false,
-      "quiet": true
-    },
-    "result": "success",
-    "error": ""
-  },
-  {
-    "name": "create-pod-resources-limits",
-    "llmConfig": {
-      "id": "shim_enabled-openai-google/gemma-3-27b-it",
-      "provider": "openai",
-      "model": "google/gemma-3-27b-it",
-      "enableToolUseShim": true,
       "quiet": true
     },
     "result": "success",
@@ -234,18 +159,6 @@
     "error": ""
   },
   {
-    "name": "create-simple-rbac",
-    "llmConfig": {
-      "id": "shim_enabled-openai-google/gemma-3-27b-it",
-      "provider": "openai",
-      "model": "google/gemma-3-27b-it",
-      "enableToolUseShim": true,
-      "quiet": true
-    },
-    "result": "success",
-    "error": ""
-  },
-  {
     "name": "debug-app-logs",
     "llmConfig": {
       "id": "shim_disabled-gemini-gemini-2.5-flash",
@@ -270,18 +183,6 @@
     "error": ""
   },
   {
-    "name": "debug-app-logs",
-    "llmConfig": {
-      "id": "shim_enabled-openai-google/gemma-3-27b-it",
-      "provider": "openai",
-      "model": "google/gemma-3-27b-it",
-      "enableToolUseShim": true,
-      "quiet": true
-    },
-    "result": "success",
-    "error": ""
-  },
-  {
     "name": "deployment-traffic-switch",
     "llmConfig": {
       "id": "shim_disabled-gemini-gemini-2.5-flash",
@@ -300,18 +201,6 @@
       "provider": "gemini",
       "model": "gemini-2.5-pro",
       "enableToolUseShim": false,
-      "quiet": true
-    },
-    "result": "success",
-    "error": ""
-  },
-  {
-    "name": "deployment-traffic-switch",
-    "llmConfig": {
-      "id": "shim_enabled-openai-google/gemma-3-27b-it",
-      "provider": "openai",
-      "model": "google/gemma-3-27b-it",
-      "enableToolUseShim": true,
       "quiet": true
     },
     "result": "success",
@@ -347,18 +236,6 @@
     "error": ""
   },
   {
-    "name": "fix-crashloop",
-    "llmConfig": {
-      "id": "shim_enabled-openai-google/gemma-3-27b-it",
-      "provider": "openai",
-      "model": "google/gemma-3-27b-it",
-      "enableToolUseShim": true,
-      "quiet": true
-    },
-    "result": "success",
-    "error": ""
-  },
-  {
     "name": "fix-image-pull",
     "llmConfig": {
       "id": "shim_disabled-gemini-gemini-2.5-flash",
@@ -388,18 +265,6 @@
     "error": ""
   },
   {
-    "name": "fix-image-pull",
-    "llmConfig": {
-      "id": "shim_enabled-openai-google/gemma-3-27b-it",
-      "provider": "openai",
-      "model": "google/gemma-3-27b-it",
-      "enableToolUseShim": true,
-      "quiet": true
-    },
-    "result": "success",
-    "error": ""
-  },
-  {
     "name": "fix-oomkilled",
     "llmConfig": {
       "id": "shim_disabled-gemini-gemini-2.5-flash",
@@ -424,18 +289,6 @@
     "error": ""
   },
   {
-    "name": "fix-oomkilled",
-    "llmConfig": {
-      "id": "shim_enabled-openai-google/gemma-3-27b-it",
-      "provider": "openai",
-      "model": "google/gemma-3-27b-it",
-      "enableToolUseShim": true,
-      "quiet": true
-    },
-    "result": "success",
-    "error": ""
-  },
-  {
     "name": "fix-pending-pod",
     "llmConfig": {
       "id": "shim_disabled-gemini-gemini-2.5-flash",
@@ -454,18 +307,6 @@
       "provider": "gemini",
       "model": "gemini-2.5-pro",
       "enableToolUseShim": false,
-      "quiet": true
-    },
-    "result": "success",
-    "error": ""
-  },
-  {
-    "name": "fix-pending-pod",
-    "llmConfig": {
-      "id": "shim_enabled-openai-google/gemma-3-27b-it",
-      "provider": "openai",
-      "model": "google/gemma-3-27b-it",
-      "enableToolUseShim": true,
       "quiet": true
     },
     "result": "success",
@@ -501,23 +342,6 @@
     "error": ""
   },
   {
-    "name": "fix-probes",
-    "llmConfig": {
-      "id": "shim_enabled-openai-google/gemma-3-27b-it",
-      "provider": "openai",
-      "model": "google/gemma-3-27b-it",
-      "enableToolUseShim": true,
-      "quiet": true
-    },
-    "result": "fail",
-    "failures": [
-      {
-        "message": "verifier script failed"
-      }
-    ],
-    "error": ""
-  },
-  {
     "name": "fix-rbac-wrong-resource",
     "llmConfig": {
       "id": "shim_disabled-gemini-gemini-2.5-flash",
@@ -536,18 +360,6 @@
       "provider": "gemini",
       "model": "gemini-2.5-pro",
       "enableToolUseShim": false,
-      "quiet": true
-    },
-    "result": "success",
-    "error": ""
-  },
-  {
-    "name": "fix-rbac-wrong-resource",
-    "llmConfig": {
-      "id": "shim_enabled-openai-google/gemma-3-27b-it",
-      "provider": "openai",
-      "model": "google/gemma-3-27b-it",
-      "enableToolUseShim": true,
       "quiet": true
     },
     "result": "success",
@@ -578,23 +390,6 @@
     "error": ""
   },
   {
-    "name": "fix-service-routing",
-    "llmConfig": {
-      "id": "shim_enabled-openai-google/gemma-3-27b-it",
-      "provider": "openai",
-      "model": "google/gemma-3-27b-it",
-      "enableToolUseShim": true,
-      "quiet": true
-    },
-    "result": "fail",
-    "failures": [
-      {
-        "message": "verifier script failed"
-      }
-    ],
-    "error": ""
-  },
-  {
     "name": "fix-service-with-no-endpoints",
     "llmConfig": {
       "id": "shim_disabled-gemini-gemini-2.5-flash",
@@ -616,23 +411,6 @@
       "quiet": true
     },
     "result": "success",
-    "error": ""
-  },
-  {
-    "name": "fix-service-with-no-endpoints",
-    "llmConfig": {
-      "id": "shim_enabled-openai-google/gemma-3-27b-it",
-      "provider": "openai",
-      "model": "google/gemma-3-27b-it",
-      "enableToolUseShim": true,
-      "quiet": true
-    },
-    "result": "fail",
-    "failures": [
-      {
-        "message": "verifier script failed"
-      }
-    ],
     "error": ""
   },
   {
@@ -670,23 +448,6 @@
     "error": ""
   },
   {
-    "name": "horizontal-pod-autoscaler",
-    "llmConfig": {
-      "id": "shim_enabled-openai-google/gemma-3-27b-it",
-      "provider": "openai",
-      "model": "google/gemma-3-27b-it",
-      "enableToolUseShim": true,
-      "quiet": true
-    },
-    "result": "fail",
-    "failures": [
-      {
-        "message": "verifier script failed"
-      }
-    ],
-    "error": ""
-  },
-  {
     "name": "list-images-for-pods",
     "llmConfig": {
       "id": "shim_disabled-gemini-gemini-2.5-flash",
@@ -711,23 +472,6 @@
     "error": ""
   },
   {
-    "name": "list-images-for-pods",
-    "llmConfig": {
-      "id": "shim_enabled-openai-google/gemma-3-27b-it",
-      "provider": "openai",
-      "model": "google/gemma-3-27b-it",
-      "enableToolUseShim": true,
-      "quiet": true
-    },
-    "result": "fail",
-    "failures": [
-      {
-        "message": "regex \"docker.io/bitnami/mysql:8.0.33-debian-11-r17\" did not match output \"\\x1b[0m\\n  The kubectl get pods command returned 'No resources found in default        \\n  namespace'. This confirms that there are currently no pods running in the   \\n  default namespace. Since the user did not specify a namespace, I will inform\\n  them that no pods are running in the default namespace. I should also       \\n  mention they can specify a namespace to check other namespaces.There are    \\n  currently no pods running in the default namespace. If you have pods running\\n  in a different namespace, please specify the namespace to check.            \\n\\n\""
-      }
-    ],
-    "error": ""
-  },
-  {
     "name": "multi-container-pod-communication",
     "llmConfig": {
       "id": "shim_disabled-gemini-gemini-2.5-flash",
@@ -746,18 +490,6 @@
       "provider": "gemini",
       "model": "gemini-2.5-pro",
       "enableToolUseShim": false,
-      "quiet": true
-    },
-    "result": "success",
-    "error": ""
-  },
-  {
-    "name": "multi-container-pod-communication",
-    "llmConfig": {
-      "id": "shim_enabled-openai-google/gemma-3-27b-it",
-      "provider": "openai",
-      "model": "google/gemma-3-27b-it",
-      "enableToolUseShim": true,
       "quiet": true
     },
     "result": "success",
@@ -793,23 +525,6 @@
     "error": ""
   },
   {
-    "name": "resize-pvc",
-    "llmConfig": {
-      "id": "shim_enabled-openai-google/gemma-3-27b-it",
-      "provider": "openai",
-      "model": "google/gemma-3-27b-it",
-      "enableToolUseShim": true,
-      "quiet": true
-    },
-    "result": "fail",
-    "failures": [
-      {
-        "message": "verifier script failed"
-      }
-    ],
-    "error": ""
-  },
-  {
     "name": "rolling-update-deployment",
     "llmConfig": {
       "id": "shim_disabled-gemini-gemini-2.5-flash",
@@ -839,23 +554,6 @@
     "error": ""
   },
   {
-    "name": "rolling-update-deployment",
-    "llmConfig": {
-      "id": "shim_enabled-openai-google/gemma-3-27b-it",
-      "provider": "openai",
-      "model": "google/gemma-3-27b-it",
-      "enableToolUseShim": true,
-      "quiet": true
-    },
-    "result": "fail",
-    "failures": [
-      {
-        "message": "verifier script failed"
-      }
-    ],
-    "error": ""
-  },
-  {
     "name": "scale-deployment",
     "llmConfig": {
       "id": "shim_disabled-gemini-gemini-2.5-flash",
@@ -874,18 +572,6 @@
       "provider": "gemini",
       "model": "gemini-2.5-pro",
       "enableToolUseShim": false,
-      "quiet": true
-    },
-    "result": "success",
-    "error": ""
-  },
-  {
-    "name": "scale-deployment",
-    "llmConfig": {
-      "id": "shim_enabled-openai-google/gemma-3-27b-it",
-      "provider": "openai",
-      "model": "google/gemma-3-27b-it",
-      "enableToolUseShim": true,
       "quiet": true
     },
     "result": "success",
@@ -916,18 +602,6 @@
     "error": ""
   },
   {
-    "name": "scale-down-deployment",
-    "llmConfig": {
-      "id": "shim_enabled-openai-google/gemma-3-27b-it",
-      "provider": "openai",
-      "model": "google/gemma-3-27b-it",
-      "enableToolUseShim": true,
-      "quiet": true
-    },
-    "result": "success",
-    "error": ""
-  },
-  {
     "name": "setup-dev-cluster",
     "llmConfig": {
       "id": "shim_disabled-gemini-gemini-2.5-flash",
@@ -949,23 +623,6 @@
       "quiet": true
     },
     "result": "success",
-    "error": ""
-  },
-  {
-    "name": "setup-dev-cluster",
-    "llmConfig": {
-      "id": "shim_enabled-openai-google/gemma-3-27b-it",
-      "provider": "openai",
-      "model": "google/gemma-3-27b-it",
-      "enableToolUseShim": true,
-      "quiet": true
-    },
-    "result": "fail",
-    "failures": [
-      {
-        "message": "verifier script failed"
-      }
-    ],
     "error": ""
   },
   {
@@ -995,23 +652,6 @@
       "quiet": true
     },
     "result": "success",
-    "error": ""
-  },
-  {
-    "name": "statefulset-lifecycle",
-    "llmConfig": {
-      "id": "shim_enabled-openai-google/gemma-3-27b-it",
-      "provider": "openai",
-      "model": "google/gemma-3-27b-it",
-      "enableToolUseShim": true,
-      "quiet": true
-    },
-    "result": "fail",
-    "failures": [
-      {
-        "message": "verifier script failed"
-      }
-    ],
     "error": ""
   }
 ]

--- a/k8s-bench.md
+++ b/k8s-bench.md
@@ -6,14 +6,13 @@
 |-------|---------|------|
 | gemini-2.5-flash | 17 | 8 |
 | gemini-2.5-pro | 23 | 2 |
-| google/gemma-3-27b-it | 13 | 12 |
-| **Total** | 53 | 22 |
+| **Total** | 40 | 10 |
 
 ## Overall Summary
 
-- Total Runs: 75
-- Overall Success: 53 (70%)
-- Overall Fail: 22 (29%)
+- Total Runs: 50
+- Overall Success: 40 (80%)
+- Overall Fail: 10 (20%)
 
 ## Model: gemini-2.5-flash
 
@@ -86,42 +85,6 @@
 - Total: 25
 - Success: 23 (92%)
 - Fail: 2 (8%)
-
-## Model: google/gemma-3-27b-it
-
-| Task | Provider | Result |
-|------|----------|--------|
-| create-canary-deployment | openai | ❌ fail |
-| create-network-policy | openai | ❌ fail |
-| create-pod | openai | ✅ success |
-| create-pod-mount-configmaps | openai | ❌ fail |
-| create-pod-resources-limits | openai | ✅ success |
-| create-simple-rbac | openai | ✅ success |
-| debug-app-logs | openai | ✅ success |
-| deployment-traffic-switch | openai | ✅ success |
-| fix-crashloop | openai | ✅ success |
-| fix-image-pull | openai | ✅ success |
-| fix-oomkilled | openai | ✅ success |
-| fix-pending-pod | openai | ✅ success |
-| fix-probes | openai | ❌ fail |
-| fix-rbac-wrong-resource | openai | ✅ success |
-| fix-service-routing | openai | ❌ fail |
-| fix-service-with-no-endpoints | openai | ❌ fail |
-| horizontal-pod-autoscaler | openai | ❌ fail |
-| list-images-for-pods | openai | ❌ fail |
-| multi-container-pod-communication | openai | ✅ success |
-| resize-pvc | openai | ❌ fail |
-| rolling-update-deployment | openai | ❌ fail |
-| scale-deployment | openai | ✅ success |
-| scale-down-deployment | openai | ✅ success |
-| setup-dev-cluster | openai | ❌ fail |
-| statefulset-lifecycle | openai | ❌ fail |
-
-**google/gemma-3-27b-it Summary**
-
-- Total: 25
-- Success: 13 (52%)
-- Fail: 12 (48%)
 
 ---
 


### PR DESCRIPTION
Updating k8s-bench.md and k8s-bench.json with my runs from today

gemini-2.5-pro and gemini-2.5-flash were run with `--llm-provider gemini`, ~gemma-3-27b-it was served with a local vllm instance on openai endpoints and `--llm-provider openai`~