### PR TITLE
feat: Add --show-failures flag to `analyze-evals`, update scripts

### DIFF
--- a/dev/ci/periodics/analyze-evals.sh
+++ b/dev/ci/periodics/analyze-evals.sh
@@ -21,5 +21,12 @@ cd "${REPO_ROOT}/k8s-bench"
 go build -o "${BINDIR}/k8s-bench" .
 
 cd "${REPO_ROOT}"
-"${BINDIR}/k8s-bench" analyze --input-dir "${OUTPUT_DIR}" ${TEST_ARGS:-} -results-filepath ${REPO_ROOT}/.build/k8s-bench.md --output-format markdown
+
+# Pass --show-failures flag to the analyze command if it's set
+ANALYZE_ARGS=""
+if [[ "$*" == *"--show-failures"* ]]; then
+    ANALYZE_ARGS="--show-failures"
+fi
+
+"${BINDIR}/k8s-bench" analyze --input-dir "${OUTPUT_DIR}" ${TEST_ARGS:-} -results-filepath ${REPO_ROOT}/.build/k8s-bench.md --output-format markdown ${ANALYZE_ARGS}
 "${BINDIR}/k8s-bench" analyze --input-dir "${OUTPUT_DIR}" ${TEST_ARGS:-} -results-filepath ${REPO_ROOT}/.build/k8s-bench.json --output-format json

--- a/k8s-bench/eval.go
+++ b/k8s-bench/eval.go
@@ -201,6 +201,15 @@ func loadTasks(config EvalConfig) (map[string]Task, error) {
 	return tasks, nil
 }
 
+// getLastNLines returns the last n lines of a string.
+func getLastNLines(s string, n int) (string, bool) {
+	lines := strings.Split(s, "\n")
+	if len(lines) > n {
+		return strings.Join(lines[len(lines)-n:], "\n"), true
+	}
+	return s, false
+}
+
 func evaluateTask(ctx context.Context, config EvalConfig, taskID string, task Task, llmConfig model.LLMConfig, log io.Writer) model.TaskResult {
 	result := model.TaskResult{
 		Task:      taskID,
@@ -209,12 +218,18 @@ func evaluateTask(ctx context.Context, config EvalConfig, taskID string, task Ta
 
 	taskOutputDir := filepath.Join(config.OutputDir, taskID, llmConfig.ID)
 
+	var logBuffer bytes.Buffer
+	multiWriter := io.MultiWriter(&logBuffer)
+	if log != nil {
+		multiWriter = io.MultiWriter(log, &logBuffer)
+	}
+
 	x := &TaskExecution{
 		AgentBin:      config.AgentBin,
 		kubeConfig:    config.KubeConfig,
 		result:        &result,
 		llmConfig:     llmConfig,
-		log:           log,
+		log:           multiWriter,
 		task:          &task,
 		taskID:        taskID,
 		taskOutputDir: taskOutputDir,
@@ -302,7 +317,24 @@ func evaluateTask(ctx context.Context, config EvalConfig, taskID string, task Ta
 		if err == nil {
 			verifierSucceeded = true
 		} else {
-			result.AddFailure("verifier script failed")
+			const maxLogLines = 20
+			logString := logBuffer.String()
+			logTail, truncated := getLastNLines(logString, maxLogLines)
+			// build log file path
+			shimSegment := "shim_disabled"
+			if x.llmConfig.EnableToolUseShim {
+				shimSegment = "shim_enabled"
+			}
+			logPath := filepath.Join(
+				config.OutputDir,
+				taskID,
+				shimSegment+"-"+x.llmConfig.ProviderID+"-"+x.llmConfig.ModelID,
+			)
+			failureMessage := fmt.Sprintf("verifier script failed: %v\n---LOG---\n%s", err, logTail)
+			if truncated {
+				failureMessage += fmt.Sprintf("\n... (log truncated, full log at %s)", logPath)
+			}
+			result.AddFailure(failureMessage)
 		}
 	}
 

--- a/k8s-bench/eval.go
+++ b/k8s-bench/eval.go
@@ -334,7 +334,7 @@ func evaluateTask(ctx context.Context, config EvalConfig, taskID string, task Ta
 			if truncated {
 				failureMessage += fmt.Sprintf("\n... (log truncated, full log at %s)", logPath)
 			}
-			result.AddFailure(failureMessage)
+			result.AddFailure("%s", failureMessage)
 		}
 	}
 

--- a/k8s-bench/eval.go
+++ b/k8s-bench/eval.go
@@ -459,6 +459,7 @@ func (x *TaskExecution) runAgent(ctx context.Context) (string, error) {
 		"--model", x.llmConfig.ModelID,
 		"--trace-path", tracePath,
 		"--skip-permissions",
+		"--show-tool-output",
 	}
 
 	stdinReader, stdinWriter := io.Pipe()

--- a/makefile
+++ b/makefile
@@ -106,7 +106,7 @@ run-evals: ## Run evaluations (periodic task)
 
 analyze-evals: ## Analyze evaluations (periodic task)
 	@echo "λ Analyzing evaluations..."
-	./dev/ci/periodics/analyze-evals.sh
+	./dev/ci/periodics/analyze-evals.sh $(ARGS)
 
 # --- Combined Tasks ---
 # 'check' depends on other verification tasks. They will run as prerequisites.


### PR DESCRIPTION
This change adds the last 20 lines for any eval failure to the failure message, and shows it in the generated markdown file from `k8s-bench analyze` if you include the `--show-failures flag`.

Usable with ./k8s-bench analyze (other args) --show-failures
Also usable with the make target, so we can run `make analyze-evals ARGS=--show-failures`

An example of what will show up in the generated markdown file:
```markdown
## Model: openai/gpt-oss-20b

| Task | Provider | Result |
|------|----------|--------|
| create-canary-deployment | openai | ❌ fail |

**openai/gpt-oss-20b Summary**

- Total: 1
- Success: 0 (0%)
- Fail: 1 (100%)


**openai/gpt-oss-20b Failure Details**

**Task: create-canary-deployment**

verifier script failed: running command ~/kubectl-ai/k8s-bench/tasks/create-canary-deployment/verify.sh: exit status 1
---LOG---
   labels**                           | new deployment to be picked up (or    
                                      | a special label if we’re routing      
                                      | explicitly)                           
                                                                              
  **Quick check**: Do you want the canary traffic to be routed automatically  
  via an Ingress/Service Mesh annotation, or would you prefer a separate      
  service with a traffic‑splitting approach? If you’re using something like   
  Istio, that greatly simplifies the 90/10 split.                             
                                                                              
  Once you give me those specifics (or we run a brief kubectl get namespaces &
  kubectl get deployment engine-v2-0 -o yaml), I’ll craft the exact kubectl   
  apply                                                                       
  commands (including a final confirmation). Feel free to supply any other    
  constraints you might have! 🚀                                              


Received signal, shutting down gracefully... (press Ctrl+C again to force)
Error from server (NotFound): deployments.apps "engine-v2-1" not found
ERROR: Failed to find available canary deployment: 'engine-v2-1'.

... (log truncated, full log at .build/k8sbench/create-canary-deployment/shim_disabled-openai-openai/gpt-oss-20b)
```

This gives us a quick view of the failed eval, where we can see that it's asking for clarification and fails because it waited for user input. This can be helpful for quickly classifying what type of failure each task had for a model.


The same log lines also show up in the json output for failures. Example:
```json
  {
    "name": "create-canary-deployment",
    "llmConfig": {
      "id": "shim_disabled-openai-openai/gpt-oss-20b",
      "provider": "openai",
      "model": "openai/gpt-oss-20b",
      "enableToolUseShim": false,
      "quiet": true
    },
    "result": "fail",
    "failures": [
      {
        "message": "verifier script failed: running command ~/kubectl-ai/k8s-bench/tasks/create-canary-deployment/verify.sh: exit status 1\n---LOG---\nnamespace/canary-deployment-ns created\ndeployment.apps/engine-v2-0 created\nservice/recommendation-engine created\n\u001b[32m\n  Running: kubectl get deployments -o json\n\u001b[0m\n  I couldn’t find any deployments in the cluster with the name engine-v2-0.   \n                                                                              \n  **Could you please tell me in which namespace the current **engine‑v2‑0**   \n  deployment lives?**                                                         \n                                                                              \n  (If you’re unsure, I can list all namespaces for you.)                      \n\nError from server (NotFound): deployments.apps \"engine-v2-1\" not found\nERROR: Failed to find available canary deployment: 'engine-v2-1'.\n"
      }
    ],
    "error": ""
  },
  ```