### PR TITLE
fix: `auth` directive being ignored in mcp.yaml config

### DIFF
--- a/pkg/mcp/manager.go
+++ b/pkg/mcp/manager.go
@@ -104,11 +104,13 @@ func (m *Manager) ConnectAll(ctx context.Context) error {
 
 		// Create client config with environment map
 		config := ClientConfig{
-			Name:    serverCfg.Name,
-			Command: serverCfg.Command,
-			Args:    serverCfg.Args,
-			Env:     envSlice,
-			URL:     serverCfg.URL,
+			Name:        serverCfg.Name,
+			Command:     serverCfg.Command,
+			Args:        serverCfg.Args,
+			Auth:        serverCfg.Auth,
+			OAuthConfig: serverCfg.OAuthConfig,
+			Env:         envSlice,
+			URL:         serverCfg.URL,
 		}
 
 		client := NewClient(config)


### PR DESCRIPTION
Previously, the `servers.auth` field was ignored even if specified in the `mcp.yaml` config file, which made it impossible to connect to any MCP server requiring authentication. The issue seemed to boil down to those fields not being copied from the server config to the `ClientConfig` object.