### PR TITLE
feat: Add timer to eval runs

### DIFF
--- a/k8s-bench/main.go
+++ b/k8s-bench/main.go
@@ -179,6 +179,7 @@ func run(ctx context.Context) error {
 }
 
 func runEvals(ctx context.Context) error {
+	start := time.Now()
 	config := EvalConfig{
 		TasksDir: "./tasks",
 	}
@@ -268,6 +269,7 @@ func runEvals(ctx context.Context) error {
 		return fmt.Errorf("running evaluation: %w", err)
 	}
 
+	fmt.Printf("Total evaluation time: %s\n", time.Since(start))
 	return nil
 }
 


### PR DESCRIPTION
It's useful to know how long it took to run a set of evals, this makes it easy to look back and see.

Output looks like:

```
...
...
Task: create-network-policy
  LLM Config: {ID:shim_disabled-gemini-gemini-2.5-flash ProviderID:gemini ModelID:gemini-2.5-flash EnableToolUseShim:false Quiet:true}
    success
Total evaluation time: 1m56.134611226s
```