### PR TITLE
feat: Add retry in case of no function calls and no streamed text

### DIFF
--- a/pkg/agent/conversation.go
+++ b/pkg/agent/conversation.go
@@ -552,7 +552,7 @@ func (c *Agent) Run(ctx context.Context, initialQuery string) error {
 				// If no function calls to be made and no text response, retry
 				if len(functionCalls) == 0 && streamedText == "" {
 					log.Info("Empty response from LLM, re-trying.")
-					c.currChatContent = sentChatContent // Restore the content
+					c.currChatContent = sentChatContent   // Restore the content
 					c.currIteration = c.currIteration + 1 // Increment the iteration to make sure we don't infinite loop
 					continue
 				}


### PR DESCRIPTION
I've been running benchmarks locally with vllm to test open models, and in this I've found I can reliably make kubectl-ai hang in quiet mode with commands like `echo "Create a read-only role for pods bound to my reader-sa service account in the create-simple-rbac namespace." | ../cmd/cmd --kubeconfig ~/.kube/config --llm-provider openai --model openai/gpt-oss-120b --skip-permissions --alsologtostderr --quiet` (which is from the create-simple-rbac eval).

After digging into it, I found that empty responses from inference server (no function calls and no streamed text) could cause kubectl-ai to hang in quite mode.