### PR TITLE
fix: handle empty LLM response

### DIFF
--- a/pkg/agent/conversation.go
+++ b/pkg/agent/conversation.go
@@ -555,6 +555,13 @@ func (c *Agent) Run(ctx context.Context, initialQuery string) error {
 					c.currIteration = 0
 					c.pendingFunctionCalls = []ToolCallAnalysis{}
 					log.Info("Agent task completed, transitioning to done state")
+					if streamedText == "" {
+						// If no tool calls to be made and we do not have a response from the LLM
+						// we should let the user know for better diagnostics.
+						// IMPORTANT: This also prevents UIs from getting blocked on reading from the output channel.
+						log.Info("Empty response with no tool calls from LLM.")
+						c.addMessage(api.MessageSourceAgent, api.MessageTypeText, "Empty response from LLM")
+					}
 					continue
 				}
 


### PR DESCRIPTION
We noticed that sometimes LLM respond with empty text even when no tool call is being made. This results in `kubectl-ai` to hang because terminal UI (or other UIs) will get blocked on reading from the agent's output channel.

This PR ensures that we let the users know in case LLM responded with no text and it also avoids UIs blocking on the output channel. 