### PR TITLE
feat: add llm request/response tracing, http client timeout

### DIFF
--- a/gollm/factory.go
+++ b/gollm/factory.go
@@ -194,7 +194,9 @@ func DefaultIsRetryableError(err error) bool {
 // This is shared by all providers that need custom HTTP transport.
 func createCustomHTTPClient(skipVerify bool) *http.Client {
 	if !skipVerify {
-		return http.DefaultClient
+		httpClient := http.DefaultClient
+		httpClient.Timeout = 60 * time.Second
+		return httpClient
 	}
 	return &http.Client{
 		Transport: &http.Transport{
@@ -203,6 +205,7 @@ func createCustomHTTPClient(skipVerify bool) *http.Client {
 				InsecureSkipVerify: true,
 			},
 		},
+		Timeout: 60 * time.Second,
 	}
 }
 


### PR DESCRIPTION
* adds timeout to http client (the default is 0 - no timeout)
* adds llm request and response tracing to the trace file, this is helpful for debugging

Example tracefile:
```yaml
action: llm.request
payload:
- Create a read-only role for pods bound to my reader-sa service account in the create-simple-rbac
  namespace.
timestamp: "2025-09-30T11:27:13.49796764-07:00"


---

action: llm.response
payload:
  raw:
    candidates:
    - content:
        parts:
        - functionCall:
            args:
              command: kubectl get namespace create-simple-rbac
              modifies_resource: "no"
            name: kubectl
          thoughtSignature: CiQ... (cut for length)
        role: model
      finishReason: STOP
    modelVersion: gemini-2.5-flash
    usageMetadata:
      candidatesTokenCount: 27
      promptTokenCount: 1986
      promptTokensDetails:
      - modality: TEXT
        tokenCount: 1986
      thoughtsTokenCount: 157
      totalTokenCount: 2170
timestamp: "2025-09-30T11:27:15.739637629-07:00"


---

action: llm.request
payload:
- name: kubectl
  result:
    command: /usr/bin/bash -c kubectl get namespace create-simple-rbac
    stdout: |
      NAME                 STATUS   AGE
      create-simple-rbac   Active   2s
timestamp: "2025-09-30T11:27:15.848528477-07:00"


---

... (cut for length)
```