### PR TITLE
feat: Add ability to create new kind cluster for k8s-bench run

### DIFF
--- a/k8s-bench/main.go
+++ b/k8s-bench/main.go
@@ -94,12 +94,13 @@ type Expectation struct {
 }
 
 type EvalConfig struct {
-	LLMConfigs  []model.LLMConfig
-	KubeConfig  string
-	TasksDir    string
-	TaskPattern string
-	AgentBin    string
-	Concurrency int
+	LLMConfigs        []model.LLMConfig
+	KubeConfig        string
+	TasksDir          string
+	TaskPattern       string
+	AgentBin          string
+	Concurrency       int
+	CreateKindCluster bool
 
 	OutputDir string
 }
@@ -207,6 +208,7 @@ func runEvals(ctx context.Context) error {
 	flag.BoolVar(&enableToolUseShim, "enable-tool-use-shim", enableToolUseShim, "Enable tool use shim")
 	flag.BoolVar(&quiet, "quiet", quiet, "Quiet mode (non-interactive mode)")
 	flag.IntVar(&config.Concurrency, "concurrency", 0, "Number of tasks to run concurrently (0 = auto, 1 = sequential)")
+	flag.BoolVar(&config.CreateKindCluster, "create-kind-cluster", false, "Create a temporary kind cluster for the evaluation run")
 	flag.StringVar(&config.OutputDir, "output-dir", config.OutputDir, "Directory to write results to")
 	flag.Parse()
 


### PR DESCRIPTION
* adds --create-kind-cluster flag to k8s-bench, which will create a new kind cluster for the invoked run, and delete it at the end

In testing, I noticed rarely that the kind cluster control plane can fail to come up and will close the program.