### PR TITLE
refactor(transports): remove SSE server mode

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -98,7 +98,7 @@ type Options struct {
 	MaxIterations int  `json:"maxIterations,omitempty"`
 	// MCPServerMode is the mode of the MCP server. only works with --mcp-server.
 	MCPServerMode string `json:"mcpServerMode,omitempty"`
-	// Set the HTTP endpoint port for the MCP server when using HTTP transports like SSE or streamable-http.
+	// Set the HTTP endpoint port for the MCP server when using HTTP transports like streamable-http.
 	HTTPPort int `json:"httpPort,omitempty"`
 	// KubeConfigPath is the path to the kubeconfig file.
 	// If not provided, the default kubeconfig path will be used.
@@ -166,8 +166,8 @@ func (o *Options) InitDefaults() {
 	// Default to not skipping SSL verification
 	o.SkipVerifySSL = false
 	// Default MCP server mode is stdio
-	o.MCPServerMode = "stdio" // Default port for HTTP endpoint when using SSE or streamable-http modes
-	// Default port for HTTP endpoint when using SSE or streamable-http modes
+	o.MCPServerMode = "stdio"
+	// Default port for HTTP endpoint when using streamable-http mode
 	o.HTTPPort = 9080
 
 	// Session management options
@@ -307,8 +307,8 @@ func (opt *Options) bindCLIFlags(f *pflag.FlagSet) error {
 	f.BoolVar(&opt.ExternalTools, "external-tools", opt.ExternalTools, "in MCP server mode, discover and expose external MCP tools")
 	f.StringArrayVar(&opt.ToolConfigPaths, "custom-tools-config", opt.ToolConfigPaths, "path to custom tools config file or directory")
 	f.BoolVar(&opt.MCPClient, "mcp-client", opt.MCPClient, "enable MCP client mode to connect to external MCP servers")
-	f.StringVar(&opt.MCPServerMode, "mcp-server-mode", opt.MCPServerMode, "mode of the MCP server. Supported values: stdio, sse, streamable-http")
-	f.IntVar(&opt.HTTPPort, "http-port", opt.HTTPPort, "port for the HTTP endpoint in MCP server mode (used with --mcp-server when --mcp-server-mode is sse or streamable-http)")
+	f.StringVar(&opt.MCPServerMode, "mcp-server-mode", opt.MCPServerMode, "mode of the MCP server. Supported values: stdio, streamable-http")
+	f.IntVar(&opt.HTTPPort, "http-port", opt.HTTPPort, "port for the HTTP endpoint in MCP server mode (used with --mcp-server when --mcp-server-mode is streamable-http)")
 	f.BoolVar(&opt.EnableToolUseShim, "enable-tool-use-shim", opt.EnableToolUseShim, "enable tool use shim")
 	f.BoolVar(&opt.Quiet, "quiet", opt.Quiet, "run in non-interactive mode, requires a query to be provided as a positional argument")
 

--- a/cmd/mcp.go
+++ b/cmd/mcp.go
@@ -32,7 +32,7 @@ type kubectlMCPServer struct {
 	tools         tools.Tools
 	workDir       string
 	mcpManager    *mcp.Manager // Add MCP manager for external tool calls
-	mcpServerMode string       // Server mode (e.g., "streamable-http", "sse")
+	mcpServerMode string       // Server mode (e.g., "streamable-http", "stdio")
 	httpPort      int          // Port for HTTP-based server modes
 }
 
@@ -164,13 +164,6 @@ func (s *kubectlMCPServer) Serve(ctx context.Context) error {
 	klog.Info("Starting kubectl-ai MCP server")
 
 	switch s.mcpServerMode {
-	case "sse":
-		// Start the server in SSE mode
-		klog.Infof("Starting MCP server in SSE mode on port %d", s.httpPort)
-		sseServer := server.NewSSEServer(s.server)
-		endpoint := fmt.Sprintf(":%d", s.httpPort)
-		klog.Infof("Listening for SSE connections on port %d", s.httpPort)
-		return sseServer.Start(endpoint)
 	case "streamable-http":
 		// Start the server in streamable HTTP mode
 		klog.Infof("Starting MCP server in streamable HTTP mode on port %d", s.httpPort)

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -31,7 +31,7 @@ Run the server with the streamable HTTP transport to serve compatible MCP client
 kubectl-ai --mcp-server --mcp-server-mode streamable-http --http-port 9080
 ```
 
-This listens on `http://localhost:9080/mcp` by default. Use `--mcp-server-mode sse` for legacy HTTP+SSE clients.
+This listens on `http://localhost:9080/mcp` by default.
 
 ## Configuration
 
@@ -132,8 +132,8 @@ Additional tools available depend on configured MCP servers:
 | `--mcp-server` | `false` | Run in MCP server mode |
 | `--external-tools` | `false` | Discover and expose external MCP tools (requires --mcp-server) |
 | `--kubeconfig` | `~/.kube/config` | Path to kubeconfig file |
-| `--mcp-server-mode` | `stdio` | Transport for the MCP server (`stdio`, `sse`, or `streamable-http`) |
-| `--http-port` | `9080` | Port for the HTTP endpoint when using `sse` or `streamable-http` modes |
+| `--mcp-server-mode` | `stdio` | Transport for the MCP server (`stdio` or `streamable-http`) |
+| `--http-port` | `9080` | Port for the HTTP endpoint when using `streamable-http` mode |
 
 ## Architecture
 


### PR DESCRIPTION
- Remove support and documentation for MCP server SSE mode
- Update descriptions and flag help messages to reflect only supported stdio and streamable-http modes
- Clarify that HTTP port is only used with streamable-http mode
- Remove code paths related to SSE server startup