### PR TITLE
docs: standardize and clarify Markdown documentation formatting

### DIFF
--- a/CONTAINER.md
+++ b/CONTAINER.md
@@ -1,6 +1,9 @@
-# 1. Build the Docker Image 
+# Running kubectl-ai in a Docker Container
 
-First, clone the `kubectl-ai` repository and build the Docker image from the source code.
+## 1. Build the Docker Image
+
+First, clone the `kubectl-ai` repository and build the Docker image from the
+source code.
 
 ```bash
 git clone https://github.com/GoogleCloudPlatform/kubectl-ai.git
@@ -8,12 +11,16 @@ cd kubectl-ai
 docker build -t kubectl-ai:latest -f images/kubectl-ai/Dockerfile .
 ```
 
-# 2. Running against a GKE cluster
-To access a GKE cluster, `kubectl-ai` needs two configurations from your local machine: **Google Cloud credentials** and a **Kubernetes config file**.
+## 2. Running against a GKE cluster
 
-## Create Google Cloud Credentials
+To access a GKE cluster, `kubectl-ai` needs two configurations from your local
+machine: **Google Cloud credentials** and a **Kubernetes config file**.
 
-First, create Application Default Credentials [(ADC)](https://cloud.google.com/docs/authentication/application-default-credentials). `kubectl` uses these credentials to authenticate with your GKE cluster.
+### Create Google Cloud Credentials
+
+First, create Application Default Credentials
+[(ADC)](https://cloud.google.com/docs/authentication/application-default-credentials).
+`kubectl` uses these credentials to authenticate with your GKE cluster.
 
 ```bash
 gcloud auth application-default login
@@ -21,9 +28,10 @@ gcloud auth application-default login
 
 This command saves your credentials into the `~/.config/gcloud` directory.
 
-## Configure `kubectl`
+### Configure `kubectl`
 
-Next, generate the `kubeconfig` file. This file tells `kubectl` which cluster to connect to and to use your ADC credentials for authentication.
+Next, generate the `kubeconfig` file. This file tells `kubectl` which cluster
+to connect to and to use your ADC credentials for authentication.
 
 ```bash
 gcloud container clusters get-credentials <cluster-name> --location <location>
@@ -31,19 +39,30 @@ gcloud container clusters get-credentials <cluster-name> --location <location>
 
 This updates the configuration file at `~/.kube/config`.
 
-# 3. Running the Container
+## 3. Running the Container
 
-Finally, mount both configuration directories into the `kubectl-ai` container when you run it.
-This example shows how to run `kubectl-ai` with a web interface, mounting all necessary credentials and providing a Gemini API key.
+Finally, mount both configuration directories into the `kubectl-ai` container
+when you run it. This example shows how to run `kubectl-ai` with a web
+interface, mounting all necessary credentials and providing a Gemini API key.
 
 ```bash
 export GEMINI_API_KEY="your_api_key_here"
-docker run --rm -it -p 8080:8080 -v ~/.kube:/root/.kube -v ~/.config/gcloud:/root/.config/gcloud -e GEMINI_API_KEY kubectl-ai:latest --ui-listen-address 0.0.0.0:8080 --ui-type web
+docker run --rm -it -p 8080:8080 \
+  -v ~/.kube:/root/.kube \
+  -v ~/.config/gcloud:/root/.config/gcloud \
+  -e GEMINI_API_KEY \
+  kubectl-ai:latest \
+  --ui-listen-address 0.0.0.0:8080 \
+  --ui-type web
 ```
 
-Alternativley with the default terminal ui:
+Alternatively with the default terminal ui:
 
 ```bash
 export GEMINI_API_KEY="your_api_key_here"
-docker run --rm -it -v ~/.kube:/root/.kube -v ~/.config/gcloud:/root/.config/gcloud -e GEMINI_API_KEY kubectl-ai:latest 
+docker run --rm -it \
+  -v ~/.kube:/root/.kube \
+  -v ~/.config/gcloud:/root/.config/gcloud \
+  -e GEMINI_API_KEY \
+  kubectl-ai:latest
 ```


### PR DESCRIPTION
- Update section headings to use consistent Markdown formatting
- Improve readability by adding newlines and splitting long lines
- Enhance instructions for running Docker container with clearer command examples and multiline formatting
- Correct typo in the alternative terminal UI section header