### PR TITLE
Explicitly set default transport to avoid nil transport with journaling

### DIFF
--- a/gollm/factory.go
+++ b/gollm/factory.go
@@ -193,19 +193,16 @@ func DefaultIsRetryableError(err error) bool {
 // createCustomHTTPClient returns an *http.Client that optionally skips SSL certificate verification.
 // This is shared by all providers that need custom HTTP transport.
 func createCustomHTTPClient(skipVerify bool) *http.Client {
-	if !skipVerify {
-		httpClient := http.DefaultClient
-		httpClient.Timeout = 60 * time.Second
-		return httpClient
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.Proxy = http.ProxyFromEnvironment
+	if skipVerify {
+		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+
 	}
+
 	return &http.Client{
-		Transport: &http.Transport{
-			Proxy: http.ProxyFromEnvironment,
-			TLSClientConfig: &tls.Config{
-				InsecureSkipVerify: true,
-			},
-		},
-		Timeout: 60 * time.Second,
+		Transport: transport,
+		Timeout:   180 * time.Second,
 	}
 }
 


### PR DESCRIPTION
Set default transport to avoid the chance of `withJournaling` to reference nil ptr
Also set timeout from 60s -> 180s to be kinder to local llms