### PR TITLE
evals: Add per-task timeout to k8s-bench

### DIFF
--- a/k8s-bench/main.go
+++ b/k8s-bench/main.go
@@ -35,6 +35,7 @@ type Task struct {
 	Cleanup    string `json:"cleanup,omitempty"`
 	Difficulty string `json:"difficulty"`
 	Disabled   bool   `json:"disabled,omitempty"`
+	Timeout    string `json:"timeout,omitempty"`
 
 	Expect []Expectation `json:"expect,omitempty"`
 


### PR DESCRIPTION
Adds default 5 minute timeout to any task. Per-task timeout can also be set in the task.yaml