### PR TITLE
eval: Generally up timeouts for verify/setup scripts

### DIFF
--- a/k8s-bench/tasks/create-canary-deployment/verify.sh
+++ b/k8s-bench/tasks/create-canary-deployment/verify.sh
@@ -12,7 +12,7 @@ CANARY_IMAGE="nginx:1.29"
 CANARY_REPLICAS=2
 STABLE_REPLICAS=2
 EXPECTED_TOTAL_ENDPOINTS=$((CANARY_REPLICAS + STABLE_REPLICAS))
-TIMEOUT="30s"
+TIMEOUT="120s"
 
 # Wait for both deployments to be available and fully rolled out
 if ! kubectl wait deployment "$CANARY_DEPLOYMENT" -n "$NAMESPACE" \

--- a/k8s-bench/tasks/create-network-policy/setup.sh
+++ b/k8s-bench/tasks/create-network-policy/setup.sh
@@ -4,6 +4,8 @@
 kubectl delete namespace ns1 --ignore-not-found
 kubectl delete namespace ns2 --ignore-not-found
 
+TIMEOUT="120s"
+
 # Wait for namespaces to be fully deleted
 echo "Waiting for namespaces to be fully deleted..."
 while kubectl get namespace ns1 2>/dev/null || kubectl get namespace ns2 2>/dev/null; do
@@ -28,9 +30,9 @@ kubectl run curl-ns2 -n ns2 --image=curlimages/curl --command -- sleep 3600
 
 # Wait for pods to be ready
 echo "Waiting for pods to be ready..."
-kubectl wait --for=condition=Ready pod/httpd-ns1 -n ns1 --timeout=60s
-kubectl wait --for=condition=Ready pod/httpd-ns2 -n ns2 --timeout=60s
-kubectl wait --for=condition=Ready pod/curl-ns1 -n ns1 --timeout=60s
-kubectl wait --for=condition=Ready pod/curl-ns2 -n ns2 --timeout=60s
+kubectl wait --for=condition=Ready pod/httpd-ns1 -n ns1 --timeout=$TIMEOUT
+kubectl wait --for=condition=Ready pod/httpd-ns2 -n ns2 --timeout=$TIMEOUT
+kubectl wait --for=condition=Ready pod/curl-ns1 -n ns1 --timeout=$TIMEOUT
+kubectl wait --for=condition=Ready pod/curl-ns2 -n ns2 --timeout=$TIMEOUT
 
 echo "Setup completed" 

--- a/k8s-bench/tasks/create-pod-mount-configmaps/verify.sh
+++ b/k8s-bench/tasks/create-pod-mount-configmaps/verify.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 NAMESPACE="color-size-settings"
+TIMEOUT="120s"
 
 # Check if namespace exists
 if ! kubectl get namespace $NAMESPACE &>/dev/null; then
@@ -33,7 +34,7 @@ if [[ "$SIZE_VALUE" != "medium" ]]; then
 fi
 
 # Wait for pod to be ready
-if ! kubectl wait --for=condition=Ready pod/pod1 -n $NAMESPACE --timeout=60s; then
+if ! kubectl wait --for=condition=Ready pod/pod1 -n $NAMESPACE --timeout=$TIMEOUT; then
     echo "Pod 'pod1' is not ready in namespace '$NAMESPACE'"
     exit 1
 fi

--- a/k8s-bench/tasks/create-pod-resources-limits/verify.sh
+++ b/k8s-bench/tasks/create-pod-resources-limits/verify.sh
@@ -7,7 +7,8 @@ if ! kubectl get namespace limits-test &>/dev/null; then
 fi
 
 # Wait for pod to be ready
-if ! kubectl wait --for=condition=Ready pod/resource-limits-pod -n limits-test --timeout=60s; then
+TIMEOUT="120s"
+if ! kubectl wait --for=condition=Ready pod/resource-limits-pod -n limits-test --timeout=$TIMEOUT; then
     echo "Pod 'resource-limits-pod' is not ready in namespace 'limits-test'"
     exit 1
 fi

--- a/k8s-bench/tasks/debug-app-logs/setup.sh
+++ b/k8s-bench/tasks/debug-app-logs/setup.sh
@@ -6,4 +6,5 @@ kubectl apply -f artifacts/calc-app-pod.yaml --namespace=calc-app
 
 # Wait for pod to be ready
 echo "Waiting for pod to be ready..."
-kubectl wait --for=condition=Ready pod/calc-app-pod --namespace=calc-app --timeout=30s
+TIMEOUT="120s"
+kubectl wait --for=condition=Ready pod/calc-app-pod --namespace=calc-app --timeout=$TIMEOUT

--- a/k8s-bench/tasks/deployment-traffic-switch/setup.sh
+++ b/k8s-bench/tasks/deployment-traffic-switch/setup.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -e
 NAMESPACE="e-commerce"
+TIMEOUT="120s"
 
 # Create the namespace if it doesn't exist to make the script idempotent
 kubectl create namespace $NAMESPACE --dry-run=client -o yaml | kubectl apply -f -
@@ -11,9 +12,9 @@ kubectl apply -n $NAMESPACE -f artifacts/
 
 # Wait for both deployments to be available to ensure a stable starting state
 echo "Waiting for blue deployment to be ready..."
-kubectl rollout status deployment/checkout-service-blue -n $NAMESPACE --timeout=60s
+kubectl rollout status deployment/checkout-service-blue -n $NAMESPACE --timeout=$TIMEOUT
 
 echo "Waiting for green deployment to be ready..."
-kubectl rollout status deployment/checkout-service-green -n $NAMESPACE --timeout=60s
+kubectl rollout status deployment/checkout-service-green -n $NAMESPACE --timeout=$TIMEOUT
 
 echo "Setup complete. Service 'checkout-service' is pointing to 'blue'."

--- a/k8s-bench/tasks/deployment-traffic-switch/verify.sh
+++ b/k8s-bench/tasks/deployment-traffic-switch/verify.sh
@@ -3,12 +3,13 @@ set -e
 NAMESPACE="e-commerce"
 SERVICE_NAME="checkout-service"
 EXPECTED_SELECTOR_VERSION="green"
+TIMEOUT="120s"
 
 echo "Waiting for the Service '$SERVICE_NAME' to point to version '$EXPECTED_SELECTOR_VERSION'..."
 # Use 'kubectl wait' to verify the service selector condition
-if ! kubectl wait --for=jsonpath='{.spec.selector.version}'="$EXPECTED_SELECTOR_VERSION" service/$SERVICE_NAME -n $NAMESPACE --timeout=30s; then
+if ! kubectl wait --for=jsonpath='{.spec.selector.version}'="$EXPECTED_SELECTOR_VERSION" service/$SERVICE_NAME -n $NAMESPACE --timeout=$TIMEOUT; then
     echo "Failed to verify the service selector."
-    exit 0
+    exit 1
 fi
 
 echo "Service selector updated correctly."

--- a/k8s-bench/tasks/fix-image-pull/verify.sh
+++ b/k8s-bench/tasks/fix-image-pull/verify.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Wait for pod to be ready
-if kubectl wait --for=condition=Ready pod -l app=nginx -n debug --timeout=25s; then
+TIMEOUT="120s"
+if kubectl wait --for=condition=Ready pod -l app=nginx -n debug --timeout=$TIMEOUT; then
     # Get current restart count
     restarts=$(kubectl get pods -n debug -l app=nginx -o jsonpath='{.items[0].status.containerStatuses[0].restartCount}')
     

--- a/k8s-bench/tasks/fix-oomkilled/setup.sh
+++ b/k8s-bench/tasks/fix-oomkilled/setup.sh
@@ -1,22 +1,32 @@
 #!/usr/bin/env bash
-kubectl delete namespace webapp-backend --ignore-not-found
+
+NAMESPACE="webapp-backend"
+DEPLOYMENT="backend-api"
+TIMEOUT="120s"
+
+kubectl delete namespace $NAMESPACE --ignore-not-found
 
 # Create namespace
-kubectl create namespace webapp-backend
+kubectl create namespace $NAMESPACE
 
 # Apply the deployment from artifacts
 kubectl apply -f artifacts/memory-hungry-app.yaml
 
 # Wait for the deployment to be created
-kubectl rollout status deployment/backend-api -n webapp-backend --timeout=60s || true
+kubectl rollout status deployment/backend-api -n webapp-backend --timeout=$TIMEOUT || true
 
 # Wait until an OOMKilled event is detected (timeout after 30s)
 echo "Waiting for OOMKilled event to occur..."
-for i in {1..15}; do
+for i in {1..30}; do
   OOMKILLED_COUNT=$(kubectl get events -n webapp-backend --field-selector reason=OOMKilling -o json | jq '.items | length')
   if [ "$OOMKILLED_COUNT" -gt 0 ]; then
     echo "OOMKilled event detected."
+    exit 0
     break
   fi
   sleep 2
 done
+
+echo "Failed to detect OOMKilled event. Kubectl events:"
+kubectl get events -n $NAMESPACE
+exit 1

--- a/k8s-bench/tasks/fix-pending-pod/verify.sh
+++ b/k8s-bench/tasks/fix-pending-pod/verify.sh
@@ -2,10 +2,33 @@
 
 # Configuration
 POD_NAME="homepage-pod"
-NAMESPACE="homepage-ns" 
+NAMESPACE="homepage-ns"
+PVC_NAME="homepage-pvc"
+TIMEOUT="120s"
+TASK_NAME="fix-pending-pods"
 
-if ! kubectl wait --for=condition=Ready pod/$POD_NAME -n $NAMESPACE --timeout=30s; then
-  exit 1 
-else 
-  exit 0
+echo "Starting verification for $TASK_NAME..." 
+# Verify the PersistentVolumeClaim is bound
+echo "ℹWaiting for PVC '$PVC_NAME' to be 'Bound'..."
+if ! kubectl wait --for=condition=Bound pvc/$PVC_NAME -n $NAMESPACE --timeout=$TIMEOUT; then
+    echo "PVC '$PVC_NAME' did not become Bound within $TIMEOUT."
+    echo "Info for '$PVC_NAME' in namespace '$NAMESPACE':"
+    kubectl describe pvc $PVC_NAME -n $NAMESPACE
+    echo "---"
+    echo "Info for StorageClass and PersistentVolumes:"
+    kubectl get sc,pv
+    exit 1
 fi
+echo "'$PVC_NAME' is Bound. Verifying that desired state is realized..."
+
+# Verify the Pod is Ready
+echo "Waiting for Pod '$POD_NAME' to be 'Ready'..."
+if ! kubectl wait --for=condition=Ready pod/$POD_NAME -n $NAMESPACE --timeout=$TIMEOUT; then
+    echo "Pod '$POD_NAME' did not become Ready within $TIMEOUT."
+    echo "---"
+    echo "Info for Pod '$POD_NAME' in namespace '$NAMESPACE':"
+    kubectl describe pod $POD_NAME -n $NAMESPACE
+    exit 1
+fi
+echo "Pod '$POD_NAME' is Ready. Verification successful for $EVAL_NAME."
+exit 0

--- a/k8s-bench/tasks/fix-probes/verify.sh
+++ b/k8s-bench/tasks/fix-probes/verify.sh
@@ -3,8 +3,10 @@
 # Check if the pod is in Running state with Ready status
 echo "Checking if the pod is running and ready..."
 
-# Wait up to 30 seconds for pod to become ready using kubectl wait
-if kubectl wait --for=condition=Ready pod -l app=webapp -n health-check --timeout=30s; then
+TIMEOUT="120s"
+
+# Wait up to TIMEOUT seconds for pod to become ready using kubectl wait
+if kubectl wait --for=condition=Ready pod -l app=webapp -n health-check --timeout=$TIMEOUT; then
   echo "Success: Pod is now Ready"
     
     # Check if probes exist at all

--- a/k8s-bench/tasks/fix-service-routing/setup.sh
+++ b/k8s-bench/tasks/fix-service-routing/setup.sh
@@ -27,5 +27,5 @@ for i in {1..30}; do
     if kubectl get deployment nginx -n web -o jsonpath='{.status.availableReplicas}' | grep -q "1"; then
         exit 0
     fi
-    sleep 1
+    sleep 2
 done 

--- a/k8s-bench/tasks/fix-service-with-no-endpoints/setup.sh
+++ b/k8s-bench/tasks/fix-service-with-no-endpoints/setup.sh
@@ -11,9 +11,10 @@ kubectl create namespace webshop-frontend
 kubectl apply -f artifacts/service.yaml
 kubectl apply -f artifacts/deployment.yaml
 
-# Wait for the deployment to be available or timeout after 30 seconds
+# Wait for the deployment to be available or timeout after 120 seconds
 echo "Waiting for resources to be created..."
-kubectl wait --for=condition=Available=False --timeout=30s deployment/web-app-deployment -n webshop-frontend || true
+TIMEOUT="120s"
+kubectl wait --for=condition=Available=False --timeout=$TIMEOUT deployment/web-app-deployment -n webshop-frontend || true
 
 # Check the service has no endpoints (due to deployment with invalid node selector)
 ENDPOINTS=$(kubectl get endpoints web-app-service -n webshop-frontend -o jsonpath='{.subsets}')

--- a/k8s-bench/tasks/fix-service-with-no-endpoints/verify.sh
+++ b/k8s-bench/tasks/fix-service-with-no-endpoints/verify.sh
@@ -9,7 +9,8 @@ fi
 
 # Check if pods are being created successfully
 echo "Waiting for pods to become ready..."
-if ! kubectl wait --for=condition=Ready pods -l app=web-app -n webshop-frontend --timeout=60s; then
+TIMEOUT="120s"
+if ! kubectl wait --for=condition=Ready pods -l app=web-app -n webshop-frontend --timeout=$TIMEOUT; then
   echo "Pods are not reaching Ready state after fixing the node selector"
   exit 1
 fi

--- a/k8s-bench/tasks/multi-container-pod-communication/verify.sh
+++ b/k8s-bench/tasks/multi-container-pod-communication/verify.sh
@@ -3,10 +3,11 @@ set -euo pipefail
 
 NAMESPACE="multi-container-logging"
 POD_NAME="communication-pod"
+TIMEOUT="120s"
 
 # Wait for pod to be running
 echo "Waiting for pod '$POD_NAME' to be ready..."
-if ! kubectl wait --for=condition=Ready pod/$POD_NAME -n "$NAMESPACE" --timeout=60s; then
+if ! kubectl wait --for=condition=Ready pod/$POD_NAME -n "$NAMESPACE" --timeout=$TIMEOUT; then
     echo "Pod failed to reach Ready state in time"
     echo "Current pod status:"
     kubectl describe pod "$POD_NAME" -n "$NAMESPACE"

--- a/k8s-bench/tasks/resize-pvc/verify.sh
+++ b/k8s-bench/tasks/resize-pvc/verify.sh
@@ -3,6 +3,7 @@
 # Configuration
 PVC_NAME="storage-pvc" 
 EXPECTED_SIZE="15Gi"
+TIMEOUT="120s"
 
 echo "Attempting to get PV name from PVC: $PVC_NAME"
 
@@ -14,7 +15,7 @@ if [ -z "$PV_NAME" ]; then
   exit 1
 fi
 
-if ! kubectl wait --for=jsonpath='{.spec.capacity.storage}'='15Gi' pv/$PV_NAME --timeout=30s; then
+if ! kubectl wait --for=jsonpath='{.spec.capacity.storage}'='15Gi' pv/$PV_NAME --timeout=$TIMEOUT; then
   echo "FAILURE: PersistentVolume '$PV_NAME' did not reach the expected capacity of $EXPECTED_SIZE."
   exit 1 
 else 

--- a/k8s-bench/tasks/rolling-update-deployment/setup.sh
+++ b/k8s-bench/tasks/rolling-update-deployment/setup.sh
@@ -5,9 +5,11 @@ kubectl create namespace rollout-test
 kubectl create deployment web-app --image=nginx:1.21 --replicas=3 -n rollout-test
 
 # Wait until all replicas are available
-if kubectl wait deployment/web-app -n rollout-test --for=condition=Available=True --timeout=60s; then
+TIMEOUT="120s"
+if kubectl wait deployment/web-app -n rollout-test --for=condition=Available=True --timeout=$TIMEOUT; then
+  echo "Setup succeeded for rolling-update-deployment"
   exit 0
 else
-  echo "Initial deployment did not become ready in time"
+  echo "Setup failed for rolling-update-deployment. Initial deployment did not become ready in time"
   exit 1
 fi

--- a/k8s-bench/tasks/rolling-update-deployment/verify.sh
+++ b/k8s-bench/tasks/rolling-update-deployment/verify.sh
@@ -1,13 +1,46 @@
 #!/usr/bin/env bash
-# Wait for rollout to complete
-kubectl rollout status deployment/web-app -n rollout-test --timeout=120s || exit 1
+# Configuration constants
+NAMESPACE="rollout-test"
+DEPLOYMENT="web-app"
+EXPECTED_IMAGE="nginx:1.22"
+TIMEOUT="120s"
+TASK_NAME="rolling-update-deployment"
+
+echo "Starting verification for $TASK_NAME..."
+# Wait for the rollout to complete
+echo "Waiting for deployment '$DEPLOYMENT' in namespace '$NAMESPACE' to complete its rollout..."
+if ! kubectl rollout status deployment/$DEPLOYMENT -n $NAMESPACE --timeout=$TIMEOUT; then
+    echo "ERROR: Deployment rollout failed or timed out after $TIMEOUT."
+    exit 1
+fi
+echo "Deployment rollout completed successfully."
 
 # Verify each pod is running the new image
-pods=$(kubectl get pods -n rollout-test -l app=web-app -o jsonpath='{.items[*].spec.containers[0].image}')
-for img in $pods; do
-  if [[ "$img" != "nginx:1.22" ]]; then
-    exit 1
-  fi
-done
+echo "Verifying container images for all pods managed by the deployment..."
+FAILURE=0
 
-exit 0
+# Get a list of pod names and their images, separated by a space
+POD_INFO=$(kubectl get pods -n $NAMESPACE -l app=$DEPLOYMENT -o jsonpath='{range .items[*]}{.metadata.name}{" "}{.spec.containers[0].image}{"\n"}{end}')
+
+if [ -z "$POD_INFO" ]; then
+    echo "ERROR: Could not find any pods for deployment '$DEPLOYMENT'."
+    exit 1
+fi
+
+# Loop through each line of the pod info
+while read -r POD_NAME ACTUAL_IMAGE; do
+    if [[ "$ACTUAL_IMAGE" == "$EXPECTED_IMAGE" ]]; then
+        echo "PASSED: Pod '$POD_NAME' is running the correct image ($ACTUAL_IMAGE)."
+    else
+        echo "FAILED: Pod '$POD_NAME' has the wrong image. Expected: $EXPECTED_IMAGE, Found: $ACTUAL_IMAGE"
+        FAILURE=1
+    fi
+done <<< "$POD_INFO"
+
+if [ $FAILURE -eq 1 ]; then
+    echo "Verification failed: One or more pods are not running the correct image."
+    exit 1
+else 
+  echo "Verification successful for $TASK_NAME."
+  exit 0
+fi

--- a/k8s-bench/tasks/scale-deployment/setup.sh
+++ b/k8s-bench/tasks/scale-deployment/setup.sh
@@ -8,5 +8,8 @@ for i in {1..30}; do
     if kubectl get deployment web-app -n scale-test -o jsonpath='{.status.availableReplicas}' | grep -q "1"; then
         exit 0
     fi
-    sleep 1
-done 
+    sleep 2
+done
+
+echo "Setup failed for scale-deployment"
+exit 1

--- a/k8s-bench/tasks/scale-deployment/verify.sh
+++ b/k8s-bench/tasks/scale-deployment/verify.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Wait for deployment to scale to 2 replicas with kubectl wait
-if kubectl wait --for=condition=Available=True --timeout=30s deployment/web-app -n scale-test; then
+TIMEOUT="120s"
+if kubectl wait --for=condition=Available=True --timeout=$TIMEOUT deployment/web-app -n scale-test; then
     # Verify the replica count is exactly 2
     if [ "$(kubectl get deployment web-app -n scale-test -o jsonpath='{.status.availableReplicas}')" = "2" ]; then
         exit 0
@@ -8,4 +9,5 @@ if kubectl wait --for=condition=Available=True --timeout=30s deployment/web-app 
 fi
 
 # If we get here, deployment didn't scale up correctly in time
+echo "Verification failed for scale-deployment"
 exit 1 

--- a/k8s-bench/tasks/scale-down-deployment/verify.sh
+++ b/k8s-bench/tasks/scale-down-deployment/verify.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Wait for deployment to scale down to 1 replicas with kubectl wait
-if kubectl wait --for=condition=Available=True --timeout=30s deployment/web-service -n scale-down-test; then
+TIMEOUT="120s"
+if kubectl wait --for=condition=Available=True --timeout=$TIMEOUT deployment/web-service -n scale-down-test; then
     # Verify the replica count is exactly 1
     if [ "$(kubectl get deployment web-service -n scale-down-test -o jsonpath='{.status.availableReplicas}')" = "1" ]; then
         exit 0
@@ -8,4 +9,5 @@ if kubectl wait --for=condition=Available=True --timeout=30s deployment/web-serv
 fi
 
 # If we get here, deployment didn't scale down correctly in time
+echo "Verification failed for scale-down-deployment"
 exit 1 


### PR DESCRIPTION
We're seeing some timeout issues in eval runs, this change mostly ups timeout lengths as an experiment to see if it helps. A few evals also get updates to setup/verify scripts.
* fix-oomkilled was passing for no reason. It still can, if the setup doesn't create oomkilled events, but this at least checks that memory was changed
* fix-pending-pod scripts give us a little bit more visibility into what's happening
* same with rolling-update-deployment