### PR TITLE
k8s-bench: made prompt to be more specific for list-images-for-pods eval

### DIFF
--- a/k8s-bench/tasks/list-images-for-pods/task.yaml
+++ b/k8s-bench/tasks/list-images-for-pods/task.yaml
@@ -1,5 +1,5 @@
 script:
-- prompt: "What images are my pods running?"
+- prompt: "What images are all pods running in the cluster?"
 setup: "setup.sh"
 cleanup: "cleanup.sh"
 # disabled: true


### PR DESCRIPTION
Making the task goals to be more specific.