### PR TITLE
eval: (fix) Avoid race condition in fix-image-pull task

### DIFF
--- a/k8s-bench/tasks/fix-image-pull/verify.sh
+++ b/k8s-bench/tasks/fix-image-pull/verify.sh
@@ -1,19 +1,25 @@
 #!/usr/bin/env bash
-# Wait for pod to be ready
 TIMEOUT="120s"
-if kubectl wait --for=condition=Ready pod -l app=nginx -n debug --timeout=$TIMEOUT; then
-    # Get current restart count
-    restarts=$(kubectl get pods -n debug -l app=nginx -o jsonpath='{.items[0].status.containerStatuses[0].restartCount}')
+
+# Wait for the deployment rollout to complete and become "Available"
+if kubectl wait --for=condition=Available deployment/app -n debug --timeout=$TIMEOUT; then
+    # Get the restart count *only* from the new, running pod.
+    restarts=$(kubectl get pods -n debug -l app=nginx --field-selector=status.phase=Running -o jsonpath='{.items[0].status.containerStatuses[0].restartCount}')
     
     # Wait additional 5 seconds to ensure stability
     sleep 5
     
     # Check if restart count hasn't increased
-    new_restarts=$(kubectl get pods -n debug -l app=nginx -o jsonpath='{.items[0].status.containerStatuses[0].restartCount}')
+    new_restarts=$(kubectl get pods -n debug -l app=nginx --field-selector=status.phase=Running -o jsonpath='{.items[0].status.containerStatuses[0].restartCount}')
     if [[ "$restarts" == "$new_restarts" ]]; then
+        echo "Pod is stable. Verification successful."
         exit 0
+    else
+        echo "Verification failed: Pod restarted unexpectedly."
+        exit 1
     fi
 fi
 
-# If we get here, pod didn't stabilize in time
-exit 1 
+# If we get here, the deployment never became available
+echo "Verification failed: Deployment 'app' did not become Available in $TIMEOUT."
+exit 1


### PR DESCRIPTION
Checking for pods causes flakes due to a race condition; we can end up waiting for the terminating pod, timing out, and failing the task. Now, we wait until the deployment is available and check only the running pod, which should avoid the race condition.