### PR TITLE
eval: (fix) Have horizontal-pod-autoscaler check spec of hpa, not realized state

### DIFF
--- a/k8s-bench/tasks/horizontal-pod-autoscaler/verify.sh
+++ b/k8s-bench/tasks/horizontal-pod-autoscaler/verify.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Wait until HPA scales above 1 replica
+# Verify the HPA spec matches the desired state
 
 HPA_NAME=$(kubectl get hpa -n hpa-test -o jsonpath='{.items[0].metadata.name}')
 if [ -z "$HPA_NAME" ]; then
@@ -7,9 +7,32 @@ if [ -z "$HPA_NAME" ]; then
     exit 1
 fi
 
-if kubectl wait "hpa/$HPA_NAME" -n hpa-test --for=condition=ScalingActive --timeout=120s; then
-  exit 0
-else
-  echo "HPA did not scale above 1 replica in time"
-  exit 1
+HPA_JSON=$(kubectl get hpa "$HPA_NAME" -n hpa-test -o json)
+
+SCALE_TARGET_REF_NAME=$(echo "$HPA_JSON" | jq -r '.spec.scaleTargetRef.name')
+MIN_REPLICAS=$(echo "$HPA_JSON" | jq -r '.spec.minReplicas')
+MAX_REPLICAS=$(echo "$HPA_JSON" | jq -r '.spec.maxReplicas')
+TARGET_CPU_UTILIZATION=$(echo "$HPA_JSON" | jq -r '.spec.targetCPUUtilizationPercentage')
+
+if [ "$SCALE_TARGET_REF_NAME" != "web-app" ]; then
+    echo "Verification failed: Expected HPA target to be 'web-app' deployment, got '$SCALE_TARGET_REF_NAME'."
+    exit 1
 fi
+
+if [ "$MIN_REPLICAS" != "1" ]; then
+    echo "Verification failed: Expected HPA minReplicas to be set to 1, got '$MIN_REPLICAS'."
+    exit 1
+fi
+
+if [ "$MAX_REPLICAS" != "3" ]; then
+    echo "Verification failed: Expected HPA maxReplicas to be set to 3, got '$MAX_REPLICAS'."
+    exit 1
+fi
+
+if [ "$TARGET_CPU_UTILIZATION" != "50" ]; then
+    echo "Verification failed: Expected HPA targetCPUUtilizationPercentage to be set to 50, got '$TARGET_CPU_UTILIZATION'."
+    exit 1
+fi
+
+echo "Successful verification: HPA spec is configured as expected."
+exit 0


### PR DESCRIPTION
horizontal-pod-autoscaler eval previously would not work on KinD cluster because it didn't have Metrics API installed by default. In testing, rarely the agent would install metrics api. So even if the ai agent fulfilled this task like it was supposed to, we failed on verification because of some extra setup that wasn't there.

This change verifies against the spec, no longer checking for the 'ScalingActive' condition, so it will work even on clusters witohut Metrics API installed.

I tested this with gemini 2.5 pro on KinD cluster, and it passed 10/10 times. I also manually tested some bad hpa configurations (wrong number of replicas, wrong target utilization) and it failed.