### PR TITLE
k8s-bench: fix hpa eval to support autoscaling/v2 apis

### DIFF
--- a/k8s-bench/tasks/horizontal-pod-autoscaler/verify.sh
+++ b/k8s-bench/tasks/horizontal-pod-autoscaler/verify.sh
@@ -12,7 +12,8 @@ HPA_JSON=$(kubectl get hpa "$HPA_NAME" -n hpa-test -o json)
 SCALE_TARGET_REF_NAME=$(echo "$HPA_JSON" | jq -r '.spec.scaleTargetRef.name')
 MIN_REPLICAS=$(echo "$HPA_JSON" | jq -r '.spec.minReplicas')
 MAX_REPLICAS=$(echo "$HPA_JSON" | jq -r '.spec.maxReplicas')
-TARGET_CPU_UTILIZATION=$(echo "$HPA_JSON" | jq -r '.spec.targetCPUUtilizationPercentage')
+TARGET_CPU_UTILIZATION_API_V1=$(echo "$HPA_JSON" | jq -r '.spec.targetCPUUtilizationPercentage')
+TARGET_CPU_UTILIZATION_API_V2=$(echo "$HPA_JSON" | jq -r '.spec.metrics[0].resource.target.averageUtilization')
 
 if [ "$SCALE_TARGET_REF_NAME" != "web-app" ]; then
     echo "Verification failed: Expected HPA target to be 'web-app' deployment, got '$SCALE_TARGET_REF_NAME'."
@@ -29,8 +30,14 @@ if [ "$MAX_REPLICAS" != "3" ]; then
     exit 1
 fi
 
-if [ "$TARGET_CPU_UTILIZATION" != "50" ]; then
-    echo "Verification failed: Expected HPA targetCPUUtilizationPercentage to be set to 50, got '$TARGET_CPU_UTILIZATION'."
+if [ "$TARGET_CPU_UTILIZATION_API_V1" != "50" ] && [ "$TARGET_CPU_UTILIZATION_API_V2" != "50" ]; then
+    echo "Verification failed: Expected HPA target CPU utilization to be set to 50 for either v1 or v2 API, got v1: '$TARGET_CPU_UTILIZATION_API_V1', v2: '$TARGET_CPU_UTILIZATION_API_V2'."
+    exit 1
+fi
+
+echo "Waiting for HPA condition AbleToScale to be true..."
+if ! kubectl wait --for=condition=AbleToScale=true hpa/"$HPA_NAME" -n hpa-test --timeout=120s; then
+    echo "Verification failed: HPA condition AbleToScale did not become true within 120 seconds."
     exit 1
 fi
 


### PR DESCRIPTION
autoscaling/v2 apis have different syntax for specifying target cpu utilization. Tweaked the verifier to support v2 as well.

here is an example of v2 api:

```yaml
apiVersion: autoscaling/v2
kind: HorizontalPodAutoscaler
metadata:
  creationTimestamp: "2025-10-17T17:59:25Z"
  name: web-app
  namespace: hpa-test
  resourceVersion: "1306"
  uid: 9a159eb2-c5b6-47ca-971d-731c3fcc338a
spec:
  maxReplicas: 3
  metrics:
  - resource:
      name: cpu
      target:
        averageUtilization: 50
        type: Utilization
    type: Resource
  minReplicas: 1
  scaleTargetRef:
    apiVersion: apps/v1
    kind: Deployment
    name: web-app
status:
  conditions:
  - lastTransitionTime: "2025-10-17T17:59:40Z"
    message: the HPA controller was able to get the target's current scale
    reason: SucceededGetScale
    status: "True"
    type: AbleToScale
  - lastTransitionTime: "2025-10-17T17:59:40Z"
    message: 'the HPA was unable to compute the replica count: failed to get cpu utilization:
      unable to get metrics for resource cpu: unable to fetch metrics from resource
      metrics API: the server could not find the requested resource (get pods.metrics.k8s.io)'
    reason: FailedGetResourceMetric
    status: "False"
    type: ScalingActive
  currentMetrics:
  - type: ""
  currentReplicas: 1
  desiredReplicas: 0

```