### PR TITLE
eval: More realistic dev cluster prompt & update verification

### DIFF
--- a/k8s-bench/tasks/setup-dev-cluster/setup-dev-cluster.md
+++ b/k8s-bench/tasks/setup-dev-cluster/setup-dev-cluster.md
@@ -9,6 +9,7 @@ Create a secure, multi-tenant development environment with the following require
     - Developers should have read-only access to the dev-shared namespace
     - Only cluster admins should access staging and prod
     - Create service accounts for each developer (alice-sa, bob-sa, charlie-sa) in their respective namespaces
+    - Each developer's service account should have full access to their respective namespace and read-only access to the dev-shared namespace
 
 3. **Resource Quotas**:
     - Each developer namespace: max 2 CPUs, 4Gi memory, 10 pods, 5 services


### PR DESCRIPTION
Update dev cluster prompt to include instructions for both user and service account permissions, and include checks for them in verification. This should be more realistic since real setups would use both user and service account permissions, and more consistent since we're being more precise with our requirements.

Tested this with gemini 2.5 pro on kind and GKE clusters, was successful on both multiple times.