### PR TITLE
k8s-bench: Up per-task timeout (5m -> 10m)

### DIFF
--- a/k8s-bench/eval.go
+++ b/k8s-bench/eval.go
@@ -263,7 +263,8 @@ func evaluateTask(ctx context.Context, config EvalConfig, taskID string, task Ta
 		LLMConfig: llmConfig,
 	}
 
-	timeout := 5 * time.Minute
+	// Timeout limit for the whole task (setup, agent actions, verify)
+	timeout := 10 * time.Minute
 	if task.Timeout != "" {
 		var err error
 		timeout, err = time.ParseDuration(task.Timeout)


### PR DESCRIPTION
With the recent increased timeouts on setup and verify, some tasks could timeout on the 5 minute total timer. Upping it to 10 fixes this in almost all cases.

Some models I tested with very lengthy or complex reasoning (Qwen3-Next-80B-A3B-Thinking, for example) can still timeout even with 20 min per-task timeouts, but we can handle these later. I think it's better to keep the timeout reasonable and think about adding a no-timeout mode later if we're interested in long-running evals.