### PR TITLE
eval: Update create-pod's ns to avoid hinting, check that created pod image is correct

### DIFF
--- a/k8s-bench/tasks/create-pod/cleanup.sh
+++ b/k8s-bench/tasks/create-pod/cleanup.sh
@@ -1,2 +1,3 @@
 #!/usr/bin/env bash
-kubectl delete pod web-server -n create-pod-test --ignore-not-found
+NAMESPACE="web-server"
+kubectl delete namespace $NAMESPACE --ignore-not-found

--- a/k8s-bench/tasks/create-pod/setup.sh
+++ b/k8s-bench/tasks/create-pod/setup.sh
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
-kubectl delete namespace create-pod-test --ignore-not-found
-kubectl create namespace create-pod-test
+NAMESPACE="web-server"
+kubectl delete namespace $NAMESPACE --ignore-not-found
+kubectl create namespace $NAMESPACE

--- a/k8s-bench/tasks/create-pod/task.yaml
+++ b/k8s-bench/tasks/create-pod/task.yaml
@@ -1,7 +1,5 @@
 script:
-- prompt: "Please create a nginx pod named web-server in the create-pod-test namespace"
+- prompt: "Please create a nginx pod named web-server in the web-server namespace"
 verifier: "verify.sh"
 cleanup: "cleanup.sh"
 difficulty: "easy" 
-expect:
-- contains: "(nginx|proceed)"

--- a/k8s-bench/tasks/create-pod/verify.sh
+++ b/k8s-bench/tasks/create-pod/verify.sh
@@ -1,8 +1,19 @@
 #!/usr/bin/env bash
+
+NAMESPACE="web-server"
+POD="web-server"
+
 # Wait for pod to be running with kubectl wait
-if kubectl wait --for=condition=Ready pod/web-server -n create-pod-test --timeout=120s; then
-    exit 0
-else
-    # If we get here, pod didn't reach Running state in time
+if ! kubectl wait --for=condition=Ready pod/$POD -n $NAMESPACE --timeout=120s; then
+    echo "Pod $POD did not become Ready in time."
     exit 1
-fi 
+fi
+
+IMAGE=$(kubectl get pod $POD -n $NAMESPACE -o jsonpath='{.spec.containers[0].image}')
+if [ "$IMAGE" != "nginx" ]; then
+    echo "Pod is using incorrect image: $IMAGE"
+    exit 1
+fi
+
+echo "Success for create-pod. Pod is ready and using correct image."
+exit 0


### PR DESCRIPTION
Previous verification only checked that a pod existed, not that it was of the correct image. I also removed the expect block from task, since we now run k8s-bench with the modified system prompt that doesn't instruct the agent to ask for more information.

Verified this against gemini 2.5 pro with kind and gke cluster