### PR TITLE
fix: Add lastErr field to agent and return error stored there from UI

### DIFF
--- a/pkg/ui/terminal.go
+++ b/pkg/ui/terminal.go
@@ -172,7 +172,7 @@ func (u *TerminalUI) Run(ctx context.Context) error {
 	case <-ctx.Done():
 		return nil
 	case <-agentExited:
-		return nil
+		return u.agent.LastErr()
 	}
 }
 


### PR DESCRIPTION
The wait group handling I added earlier for passing errors can deadlock, instead this is simpler and requires no extra sync objects
* Removes the errChan and waitgroup way for passing errors, instead adds a lastErr field to agent and returns any error stored there when exiting the ui