### PR TITLE
refactor: standardize "ui-type" terminology across codebase

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -492,7 +492,7 @@ func RunRootCommand(ctx context.Context, opt Options, args []string) error {
 	case ui.UITypeTUI:
 		userInterface = ui.NewTUI(k8sAgent)
 	default:
-		return fmt.Errorf("user-interface mode %q is not known", opt.UIType)
+		return fmt.Errorf("ui-type mode %q is not known", opt.UIType)
 	}
 
 	return repl(ctx, queryFromCmd, userInterface, k8sAgent)

--- a/makefile
+++ b/makefile
@@ -60,7 +60,7 @@ run: ## Run the application
 
 run-html: ## Run with HTML UI
 	@echo "λ Running $(BINARY_NAME) with HTML UI from source..."
-	go run $(CMD_DIR) --user-interface html
+	go run $(CMD_DIR) --ui-type web
 
 # --- Code Quality Tasks (using dev scripts) ---
 fmt: ## Format code using dev script
@@ -121,7 +121,7 @@ dev: build ## Development mode - build and run
 
 dev-html: build ## Development mode - build and run with HTML UI
 	@echo "λ Starting $(BINARY_NAME) with HTML UI in dev mode..."
-	$(BINARY_PATH) --user-interface html
+	$(BINARY_PATH) --ui-type web
 
 # --- Maintenance Tasks ---
 clean: ## Clean build artifacts and coverage files


### PR DESCRIPTION
- Update error message wording for unknown UI type to use "ui-type" instead of "user-interface"
- Change makefile commands and flags from "--user-interface html" to "--ui-type web" for running with the HTML UI