### PR TITLE
k8s-bench: Add support for MCP client mode

### DIFF
--- a/k8s-bench/README.md
+++ b/k8s-bench/README.md
@@ -36,7 +36,7 @@ The `run` subcommand executes the benchmark evaluations.
   --llm-provider gemini \
   --models gemini-2.5-pro-preview-03-25,gemini-1.5-pro-latest \
   --enable-tool-use-shim true \
-  --quiet true \
+  --quiet \
   --concurrency 0 \
   --output-dir .build/k8sbench
 ```
@@ -55,6 +55,7 @@ The `run` subcommand executes the benchmark evaluations.
 | `--enable-tool-use-shim` | Enable tool use shim | false | No |
 | `--quiet` | Quiet mode (non-interactive mode) | true | No |
 | `--concurrency` | Number of tasks to run concurrently (0 = auto based on number of tasks, 1 = sequential, N = run N tasks at a time) | 0 | No |
+| `--mcp-client` | Enable MCP client in kubectl-ai | false | No |
 
 #### Analyze Subcommand
 

--- a/k8s-bench/eval.go
+++ b/k8s-bench/eval.go
@@ -546,6 +546,9 @@ func (x *TaskExecution) runAgent(ctx context.Context) (string, error) {
 		"--skip-permissions",
 		"--show-tool-output",
 	}
+	if x.llmConfig.McpClient {
+		args = append(args, "--mcp-client")
+	}
 
 	stdinReader, stdinWriter := io.Pipe()
 

--- a/k8s-bench/main.go
+++ b/k8s-bench/main.go
@@ -251,6 +251,7 @@ func runEvals(ctx context.Context) error {
 	defaultKubeConfig := "~/.kube/config"
 	enableToolUseShim := false
 	quiet := true
+	mcpClient := false
 
 	flag.StringVar(&config.TasksDir, "tasks-dir", config.TasksDir, "Directory containing evaluation tasks")
 	flag.StringVar(&config.KubeConfig, "kubeconfig", config.KubeConfig, "Path to kubeconfig file")
@@ -263,6 +264,7 @@ func runEvals(ctx context.Context) error {
 	flag.IntVar(&config.Concurrency, "concurrency", 0, "Number of tasks to run concurrently (0 = auto, 1 = sequential)")
 	flag.StringVar((*string)(&config.ClusterCreationPolicy), "cluster-creation-policy", string(CreateIfNotExist), "Cluster creation policy: AlwaysCreate, CreateIfNotExist, DoNotCreate")
 	flag.StringVar(&config.OutputDir, "output-dir", config.OutputDir, "Directory to write results to")
+	flag.BoolVar(&mcpClient, "mcp-client", mcpClient, "Enable MCP client in kubectl-ai")
 	flag.Parse()
 
 	if config.KubeConfig == "" {
@@ -305,6 +307,7 @@ func runEvals(ctx context.Context) error {
 				ModelID:           modelID,
 				EnableToolUseShim: enableToolUseShim,
 				Quiet:             quiet,
+				McpClient:         mcpClient,
 			})
 		}
 	}

--- a/k8s-bench/pkg/model/results.go
+++ b/k8s-bench/pkg/model/results.go
@@ -45,6 +45,8 @@ type LLMConfig struct {
 
 	Quiet bool `json:"quiet"`
 
+	McpClient bool `json:"mcpClient"`
+
 	// TODO: Maybe different styles of invocation, or different temperatures etc?
 }
 


### PR DESCRIPTION
This change introduces a new `--mcp-client` flag to the `run` subcommand in the k8s-bench tool. When this flag is enabled, `kubectl-ai` is executed with the `--mcp-client` flag, allowing it to connect to an MCP server for benchmarking.

The following changes are included:
 - Added the `--mcp-client` flag to the `run` subcommand.
 - Updated the `LLMConfig` struct to include the `McpClient` field.
 - Passed the `--mcp-client` flag to the `kubectl-ai` command in the `runAgent` function.
 - Updated the `README.md` to document the new flag.