### PR TITLE
k8s-bench: Fix for the task "debug-app-logs"

### DIFF
--- a/k8s-bench/tasks/debug-app-logs/task.yaml
+++ b/k8s-bench/tasks/debug-app-logs/task.yaml
@@ -1,7 +1,6 @@
 script:
 - prompt: "What wrong with my calc-app-pod in the calc-app namespace?"
 setup: "setup.sh"
-verifier: "verify.sh"
 cleanup: "cleanup.sh"
 difficulty: "medium"
 expect:


### PR DESCRIPTION
The task only analyses LLM response and do not have "verify" script. The verify.sh script was referenced by task.yaml that caused task to fail.

The fix removes reference to verify.sh from task.yaml