### PR TITLE
Add guide and script for running local models

### DIFF
--- a/k8s-bench/scripts/run-multi-model.md
+++ b/k8s-bench/scripts/run-multi-model.md
@@ -1,0 +1,51 @@
+# Running k8s-bench for multiple locally-served models with `run-multi-model.sh`
+
+This document outlines the steps to run the `run-multi-model.sh` script to evaluate multiple local models with `k8s-bench`.
+
+## Prerequisites
+
+Before running the script, note the following:
+
+1.  **Run from Repository Base:** The script must be executed from the root of the repository.
+
+2.  **GCE VM for Model Serving:** You need a Google Compute Engine (GCE) virtual machine to serve the models. This VM must meet the following criteria:
+    *   **Sufficient Disk Space:** The VM's boot disk or an attached persistent disk must have enough space to store the models you intend to use. For example, the GLM 4.6 model requires approximately 800GB of storage.
+    *   **NVIDIA GPUs:** The VM must be equipped with NVIDIA GPUs that have enough VRAM to load and serve the models with vllm.
+    *   **SSH Tunnel:** An active SSH tunnel must be established from your local machine to the GCE VM. You can create the tunnel using the following `gcloud` command. This command forwards traffic from your local port 8000 to the VM's port 8000.
+
+        ```bash
+        gcloud compute ssh your-gce-vm --zone=us-west1-c -- -L 8000:localhost:8000
+        ```
+    *   **If you'd like to use a setup other than GCE vm, you will have to modify `run-multi-model.sh` accordingly.**
+    *   **Spot VMs:** Pro tip: If you're having availability or stockout issues acquiring a GCE vm, or you're looking to lower its costs, spot vms are a good option, but risk getting preempted.
+
+3.  **Ensure correct settings in `run-multi-model.sh`:** Update any variables inside the script as necessary:
+    *   **GCE vm configuration:** Replace the defaults (`your-gce-vm`, `us-west1-c`, `8`) with your GCE vm's name, location, and tensor parallel size (number of NVIDIA GPUs), respectively.
+    *   **Benchmark configuration:** Change any options as you see fit: number of iterations, eval concurrency, cluster creation policy...
+    *   **Model configuration:** Add any missing models you want to benchmark, and remove any included models you do not want to benchmark. Change any vllm flags as needed (e.g., max-model-len, gpu-memory-utilization, etc.)
+    *   **Virtual environment configuration:** This script assumes your GCE vm has a virtual env with vllm and necessary dependencies installed. Such a setup might look like this:
+        ```bash
+        curl -LsSf https://astral.sh/uv/install.sh | sh
+        source $HOME/.local/bin/env
+        uv venv --python 3.12 --seed
+        source .venv/bin/acivate
+        uv pip install vllm
+        # You may need to install other packages, on Debian for example:
+        sudo apt-get update
+        sudo apt-get install build-essential python3.12-dev -y
+        ```
+
+## Usage
+
+Navigate to the root of the repository and execute the script:
+
+```bash
+./k8s-bench/scripts/run-multi-model.sh
+```
+
+## Output
+
+The script will run the `k8s-bench` evaluation for each model defined within it.
+
+*   **Multiple Runs:** For each run, the script creates a new output directory in .build/.
+*   **Directory Structure:** The output directories will contain the results of the `k8s-bench analyze` command for both markdown and json format, which includes detailed information about the model's performance on the benchmark tasks.

--- a/k8s-bench/scripts/run-multi-model.sh
+++ b/k8s-bench/scripts/run-multi-model.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+
+# --- Configuration ---
+# GCE VM Details (CHANGE THESE TO FIT YOUR OWN USAGE)
+GCE_INSTANCE_NAME="your-gce-vm"
+GCE_ZONE="us-west1-c"
+# virtual env path, for use with uv
+VENV_PATH="/home/user/.venv/bin/activate"
+# tensor parallel number (the number of GPUs on your gce vm)
+TP=8
+
+# k8s-bench configuration
+ITERATIONS=5
+CONCURRENCY=5
+CLUSTER_CREATION_POLICY="AlwaysCreate"
+
+# --- Local Evaluation Scripts ---
+LOCAL_PROGRAM_1="./dev/ci/periodics/run-eval-loop.sh -i $ITERATIONS -p openai -m openai/gpt-oss-20b -a http://localhost:8000/v1 -c $CONCURRENCY -k $CLUSTER_CREATION_POLICY"
+LOCAL_PROGRAM_2="./dev/ci/periodics/run-eval-loop.sh -i $ITERATIONS -p openai -m openai/gpt-oss-120b -a http://localhost:8000/v1 -c $CONCURRENCY -k $CLUSTER_CREATION_POLICY"
+LOCAL_PROGRAM_3="./dev/ci/periodics/run-eval-loop.sh -i $ITERATIONS -p openai -m Qwen/Qwen3-Next-80B-A3B-Instruct -a http://localhost:8000/v1 -c $CONCURRENCY -k $CLUSTER_CREATION_POLICY"
+LOCAL_PROGRAM_4="./dev/ci/periodics/run-eval-loop.sh -i $ITERATIONS -p openai -m zai-org/GLM-4.6 -a http://localhost:8000/v1 -c $CONCURRENCY -k $CLUSTER_CREATION_POLICY"
+LOCAL_PROGRAM_5="./dev/ci/periodics/run-eval-loop.sh -i $ITERATIONS -p openai -m zai-org/GLM-4.5 -a http://localhost:8000/v1 -c $CONCURRENCY -k $CLUSTER_CREATION_POLICY"
+LOCAL_PROGRAM_6="./dev/ci/periodics/run-eval-loop.sh -i $ITERATIONS -p openai -m Qwen/Qwen3-Coder-30B-A3B-Instruct -a http://localhost:8000/v1 -c $CONCURRENCY -k $CLUSTER_CREATION_POLICY"
+LOCAL_PROGRAM_7="./dev/ci/periodics/run-eval-loop.sh -i $ITERATIONS -p openai -m Qwen/Qwen3-Coder-480B-A35B-Instruct -a http://localhost:8000/v1 -c $CONCURRENCY -k $CLUSTER_CREATION_POLICY"
+
+
+# --- Remote vLLM Server Commands ---
+VLLM_START_1_CMD="source ${VENV_PATH}; nohup vllm serve openai/gpt-oss-20b -tp ${TP} > ~/vllm_server_gpt-oss-20b.log 2>&1 &"
+VLLM_START_2_CMD="source ${VENV_PATH}; nohup vllm serve openai/gpt-oss-120b -tp ${TP} > ~/vllm_server_gpt-oss-120b.log 2>&1 &"
+VLLM_START_3_CMD="source ${VENV_PATH}; nohup vllm serve Qwen/Qwen3-Next-80B-A3B-Instruct -tp ${TP} --enable-auto-tool-choice --tool-call-parser hermes --enforce-eager > ~/vllm_server_Qwen3-Next-80B.log 2>&1 &"
+VLLM_START_4_CMD="source ${VENV_PATH}; nohup vllm serve zai-org/GLM-4.6 -tp ${TP} --enable-auto-tool-choice --tool-call-parser glm45 --reasoning-parser glm45 --enforce-eager > ~/vllm_server_zai-GLM-46.log 2>&1 &"
+VLLM_START_5_CMD="source ${VENV_PATH}; nohup vllm serve zai-org/GLM-4.5 -tp ${TP} --enable-auto-tool-choice --tool-call-parser glm45 --reasoning-parser glm45 --enforce-eager > ~/vllm_server_zai-GLM-45.log 2>&1 &"
+VLLM_START_6_CMD="source ${VENV_PATH}; nohup vllm serve Qwen/Qwen3-Coder-30B-A3B-Instruct -tp ${TP} --enable-auto-tool-choice --tool-call-parser qwen3_coder --enforce-eager > ~/vllm_server_Qwen3-Coder-30B.log 2>&1 &"
+VLLM_START_7_CMD="source ${VENV_PATH}; nohup vllm serve Qwen/Qwen3-Coder-480B-A35B-Instruct -tp ${TP} --enable-auto-tool-choice --tool-call-parser qwen3_coder --enforce-eager --max-model-len 131072 > ~/vllm_server_Qwen3-Coder-480B.log 2>&1 &"
+VLLM_STOP_CMD="pkill -f 'vllm serve'"
+
+# --- Helper Function ---
+# This function handles the entire process for a single model evaluation.
+# Arguments:
+#   $1: Model Name as it appears on huggingface (e.g., "openai/gpt-oss-20b", "Qwen/Qwen3-Next-80B-A3B-Instruct")
+#   $2: The command to serve that model with vllm
+#   $3: The command to run k8s-bench
+run_model_evaluation() {
+    local model_name="$1"
+    local start_cmd="$2"
+    local eval_cmd="$3"
+
+    echo "Starting server for Model ${model_name}..."
+    gcloud compute ssh $GCE_INSTANCE_NAME --zone=$GCE_ZONE --command="${start_cmd}"
+    echo "Waiting for the server to become healthy..."
+    until curl --output /dev/null --silent --fail http://localhost:8000/health; do
+        printf '.'
+        sleep 30
+    done
+    echo -e "\nServer for Model ${model_name} is ready!"
+
+    echo "Running local evaluation for Model ${model_name}."
+    eval "${eval_cmd}"
+
+    echo "Shutting down server for Model ${model_name}..."
+    gcloud compute ssh $GCE_INSTANCE_NAME --zone=$GCE_ZONE --command="${VLLM_STOP_CMD}"
+    sleep 30 # Give time for ports to free up
+}
+
+
+# --- Main Script Logic ---
+# We assume your manual gcloud SSH tunnel is active in another terminal.
+echo "PREP: Ensuring no vLLM servers are currently running..."
+gcloud compute ssh $GCE_INSTANCE_NAME --zone=$GCE_ZONE --command="${VLLM_STOP_CMD}"
+sleep 30
+
+# Run evaluations for models that use Responses API
+export OPENAI_USE_RESPONSES_API=true
+run_model_evaluation "gpt-oss-20b" "${VLLM_START_1_CMD}" "${LOCAL_PROGRAM_1}"
+run_model_evaluation "gpt-oss-120b" "${VLLM_START_2_CMD}" "${LOCAL_PROGRAM_2}"
+unset OPENAI_USE_RESPONSES_API
+
+# Run evaluations for the remaining models on Completions API
+run_model_evaluation "Qwen/Qwen3-Next-80B-A3B-Instruct" "${VLLM_START_3_CMD}" "${LOCAL_PROGRAM_3}"
+run_model_evaluation "zai-org/GLM-4.6" "${VLLM_START_4_CMD}" "${LOCAL_PROGRAM_4}"
+run_model_evaluation "zai-org/GLM-4.5" "${VLLM_START_5_CMD}" "${LOCAL_PROGRAM_5}"
+run_model_evaluation "Qwen/Qwen3-Coder-30B-A3B-Instruct" "${VLLM_START_6_CMD}" "${LOCAL_PROGRAM_6}"
+run_model_evaluation "Qwen/Qwen3-Coder-480B-A35B-Instruct" "${VLLM_START_7_CMD}" "${LOCAL_PROGRAM_7}"
+
+# Shut down GCE VM -- no longer needed
+gcloud compute instances stop $GCE_INSTANCE_NAME --zone=$GCE_ZONE
+
+# Gemini doesn't need a local setup, we run these against the gemini api
+LOCAL_PROGRAM_GEM_PRO="./dev/ci/periodics/run-eval-loop.sh -i $ITERATIONS -p gemini -m gemini-2.5-pro -a http://localhost:8000/v1 -c $CONCURRENCY -k $CLUSTER_CREATION_POLICY"
+LOCAL_PROGRAM_GEM_FLASH="./dev/ci/periodics/run-eval-loop.sh -i $ITERATIONS -p gemini -m gemini-2.5-flash -a http://localhost:8000/v1 -c $CONCURRENCY -k $CLUSTER_CREATION_POLICY"
+eval "${LOCAL_PROGRAM_GEM_PRO}"
+eval "${LOCAL_PROGRAM_GEM_FLASH}"
+
+echo "Evaluations for all models finished successfully! You can now close your gcloud SSH tunnel."
+exit 0


### PR DESCRIPTION
Add run-multi-model.sh, a script which is meant to be paired with an existing GCE vm, for running benchmark(s) for local model(s), and a guide to help use it.
- By default it has some of the local models I've tested out previously. We can add or remove to this list as we see fit. I'm thinking it makes sense to include an exhaustive list of models, then locally comment out the ones we don't want to run.

Right now it's a bit primitive, and I have some ideas to clean it up, but I wanted to first get this in and then iterate later to make it cleaner.