### PR TITLE
(repo split) Update k8s-ai-bench scripts to download & install kubectl-ai instead of building it

### DIFF
--- a/dev/ci/periodics/run-eval-loop.sh
+++ b/dev/ci/periodics/run-eval-loop.sh
@@ -68,15 +68,14 @@ for cmd in git go; do
   fi
 done
 
-# Build kubectl-ai and k8s-ai-bench binaries
+# Install kubectl-ai and build k8s-ai-bench
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd ${REPO_ROOT}
 
 BINDIR="${REPO_ROOT}/.build/bin"
 mkdir -p "${BINDIR}"
 
-cd "${REPO_ROOT}/cmd"
-go build -o "${BINDIR}/kubectl-ai" .
+curl -sSL https://raw.githubusercontent.com/GoogleCloudPlatform/kubectl-ai/main/install.sh | bash
 
 cd "${REPO_ROOT}/k8s-ai-bench"
 go build -o "${BINDIR}/k8s-ai-bench" .
@@ -101,10 +100,10 @@ do
   
   echo "Running iteration $i of $ITERATIONS..."
 
-  K8S_AI_BENCH_ARGS="--agent-bin ${BINDIR}/kubectl-ai --kubeconfig ${KUBECONFIG:-~/.kube/config} --enable-tool-use-shim=false --llm-provider=${PROVIDER} --models=${MODEL} --quiet --output-dir=${OUTPUT_DIR} --cluster-creation-policy=${CLUSTER_CREATION_POLICY} --concurrency ${CONCURRENCY} --tasks-dir=${REPO_ROOT}/k8s-ai-bench/tasks "
+  K8S_AI_BENCH_ARGS="--agent-bin kubectl-ai --kubeconfig ${KUBECONFIG:-~/.kube/config} --enable-tool-use-shim=false --llm-provider=${PROVIDER} --models=${MODEL} --quiet --output-dir=${OUTPUT_DIR} --cluster-creation-policy=${CLUSTER_CREATION_POLICY} --concurrency ${CONCURRENCY} --tasks-dir=${REPO_ROOT}/k8s-ai-bench/tasks "
 
   if [ -n "$TASK_PATTERN" ]; then
-    TEST_ARGS+="--task-pattern=${TASK_PATTERN} "
+    K8S_AI_BENCH_ARGS+="--task-pattern=${TASK_PATTERN} "
     echo "Applying task pattern: ${TASK_PATTERN}"
   fi
 

--- a/dev/ci/periodics/run-evals.sh
+++ b/dev/ci/periodics/run-evals.sh
@@ -18,10 +18,9 @@ echo "Writing results to ${OUTPUT_DIR}"
 BINDIR="${REPO_ROOT}/.build/bin"
 mkdir -p "${BINDIR}"
 
-cd "${REPO_ROOT}/cmd"
-go build -o "${BINDIR}/kubectl-ai" .
+curl -sSL https://raw.githubusercontent.com/GoogleCloudPlatform/kubectl-ai/main/install.sh | bash
 
 cd "${REPO_ROOT}/k8s-ai-bench"
 go build -o "${BINDIR}/k8s-ai-bench" .
 
-"${BINDIR}/k8s-ai-bench" run --agent-bin "${BINDIR}/kubectl-ai" --kubeconfig "${KUBECONFIG:-~/.kube/config}" --output-dir "${OUTPUT_DIR}" ${TEST_ARGS:-}
+"${BINDIR}/k8s-ai-bench" run --agent-bin kubectl-ai --kubeconfig "${KUBECONFIG:-~/.kube/config}" --output-dir "${OUTPUT_DIR}" ${TEST_ARGS:-}

--- a/k8s-ai-bench/README.md
+++ b/k8s-ai-bench/README.md
@@ -22,7 +22,7 @@ The `run` subcommand executes the benchmark evaluations.
 ./k8s-ai-bench run --agent-bin <path/to/kubectl-ai/binary> --task-pattern scale --kubeconfig <path/to/kubeconfig> --output-dir .build/k8s-ai-bench
 
 # Run evaluation for a specific LLM provider and model with tool use shim enabled
-./k8s-ai-bench run --llm-provider=grok --models=grok-3-beta --agent-bin ../kubectl-ai --task-pattern=fix-probes --enable-tool-use-shim=true --output-dir .build/k8s-ai-bench
+./k8s-ai-bench run --llm-provider=grok --models=grok-3-beta --agent-bin kubectl-ai --task-pattern=fix-probes --enable-tool-use-shim=true --output-dir .build/k8s-ai-bench
 
 # Run evaluation sequentially (one task at a time)
 ./k8s-ai-bench run --agent-bin <path/to/kubectl-ai/binary> --tasks-dir ./tasks --output-dir .build/k8s-ai-bench --concurrency 1


### PR DESCRIPTION
(this is meant to stack with #608)
Updates run-eval-loop.sh and run-evals.sh to download and install kubectl-ai instead of building it, which will help with splitting the repos.
Do not merge this until #608 is in and this pr has been updated.