### PR TITLE
feat: Add support for JSONL benchmark output format and simplify output paths

### DIFF
--- a/dev/ci/periodics/run-eval-loop.sh
+++ b/dev/ci/periodics/run-eval-loop.sh
@@ -96,7 +96,9 @@ echo "Task Pattern: ${TASK_PATTERN:-"All Tasks"}"
 # Loop from 1 to the specified number of iterations
 for i in $(seq 1 $ITERATIONS)
 do
-  OUTPUT_DIR="${REPO_ROOT}/.build/k8s-ai-bench-${MODEL}-${i}"
+  # Create a sanitized version of model name: replace all '/' with '-'
+  SAFE_MODEL="${MODEL//\//-}"
+  OUTPUT_DIR="${REPO_ROOT}/.build/k8s-ai-bench-${SAFE_MODEL}-${i}"
   
   echo "Running iteration $i of $ITERATIONS..."
 
@@ -124,6 +126,7 @@ do
   # Paths for analysis files
   MARKDOWN_FILE="${OUTPUT_DIR}/k8s-ai-bench.md"
   JSON_FILE="${OUTPUT_DIR}/k8s-ai-bench.json"
+  JSONL_FILE="${OUTPUT_DIR}/k8s-ai-bench.jsonl"
 
   # Run for markdown format
   "${K8S_AI_BENCH_BIN}" analyze --input-dir="${OUTPUT_DIR}" --results-filepath="${MARKDOWN_FILE}" --output-format=markdown --show-failures
@@ -136,6 +139,13 @@ do
   "${K8S_AI_BENCH_BIN}" analyze --input-dir="${OUTPUT_DIR}" --results-filepath="${JSON_FILE}" --output-format=json --show-failures
   if [ $? -ne 0 ]; then
     echo "Error on iteration $i during JSON analysis. Aborting loop."
+    exit 1
+  fi
+
+  # Run for jsonl format
+  "${K8S_AI_BENCH_BIN}" analyze --input-dir="${OUTPUT_DIR}" --results-filepath="${JSONL_FILE}" --output-format=jsonl --show-failures
+  if [ $? -ne 0 ]; then
+    echo "Error on iteration $i during JSONL analysis. Aborting loop."
     exit 1
   fi
 

--- a/k8s-ai-bench/main.go
+++ b/k8s-ai-bench/main.go
@@ -360,8 +360,8 @@ func runAnalyze() error {
 	}
 
 	// Check if output format is valid
-	if config.OutputFormat != "markdown" && config.OutputFormat != "json" {
-		return fmt.Errorf("invalid output format: %s, valid options are 'markdown' or 'json'", config.OutputFormat)
+	if config.OutputFormat != "markdown" && config.OutputFormat != "json" && config.OutputFormat != "jsonl" {
+		return fmt.Errorf("invalid output format: %s, valid options are 'markdown', 'json' or 'jsonl'", config.OutputFormat)
 	}
 
 	// Check if input directory exists
@@ -375,13 +375,18 @@ func runAnalyze() error {
 	}
 
 	// Format and output results
-	if config.OutputFormat == "markdown" {
+	switch config.OutputFormat {
+	case "markdown":
 		if err := printMarkdownResults(config, allResults, resultsFilePath); err != nil {
 			return fmt.Errorf("printing markdown results: %w", err)
 		}
-	} else {
+	case "json":
 		if err := printJSONResults(allResults, resultsFilePath); err != nil {
 			return fmt.Errorf("printing JSON results: %w", err)
+		}
+	case "jsonl":
+		if err := printJSONLResults(allResults, resultsFilePath); err != nil {
+			return fmt.Errorf("printing JSONL results: %w", err)
 		}
 	}
 
@@ -752,6 +757,31 @@ func printJSONResults(results []model.TaskResult, resultsFilePath string) error 
 	} else {
 		// Print to stdout only if no file path is specified
 		fmt.Println(string(jsonData))
+	}
+
+	return nil
+}
+
+func printJSONLResults(results []model.TaskResult, resultsFilePath string) error {
+	var buffer strings.Builder
+	for _, result := range results {
+		jsonData, err := json.Marshal(result)
+		if err != nil {
+			return fmt.Errorf("marshaling result to JSON: %w", err)
+		}
+		buffer.Write(jsonData)
+		buffer.WriteString("\n")
+	}
+
+	// Write to file if path is provided, otherwise print to stdout
+	if resultsFilePath != "" {
+		if err := os.WriteFile(resultsFilePath, []byte(buffer.String()), 0644); err != nil {
+			return fmt.Errorf("writing to file %q: %w", resultsFilePath, err)
+		}
+		fmt.Printf("Results written to %s\n", resultsFilePath)
+	} else {
+		// Print to stdout only if no file path is specified
+		fmt.Print(buffer.String())
 	}
 
 	return nil


### PR DESCRIPTION
* Fixed model names with slashes added an extra directory in run-eval-loop.sh (e.g. Qwen/Qwen3-Next...)
* Add JSONL output format for `k8s-ai-bench analyze`, this will be useful for easily gathering up all run results to a single jsonl file for data processing purposes
* Simplified paths for k8s-ai-bench output in eval.go