### PR TITLE
fix: register built-in tools in MCP server mode

### DIFF
--- a/cmd/mcp.go
+++ b/cmd/mcp.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/kubectl-ai/gollm"
 	"github.com/GoogleCloudPlatform/kubectl-ai/pkg/mcp"
+	"github.com/GoogleCloudPlatform/kubectl-ai/pkg/sandbox"
 	"github.com/GoogleCloudPlatform/kubectl-ai/pkg/tools"
 	mcpgo "github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
@@ -36,7 +37,13 @@ type kubectlMCPServer struct {
 	httpPort      int          // Port for HTTP-based server modes
 }
 
-func newKubectlMCPServer(ctx context.Context, kubectlConfig string, tools tools.Tools, workDir string, exposeExternalTools bool, serverMode string, httpPort int) (*kubectlMCPServer, error) {
+func newKubectlMCPServer(ctx context.Context, kubectlConfig string, t tools.Tools, workDir string, exposeExternalTools bool, serverMode string, httpPort int) (*kubectlMCPServer, error) {
+	// Register built-in tools (bash and kubectl) which require an executor.
+	// In MCP server mode, we use a local executor since there's no sandbox.
+	executor := sandbox.NewLocalExecutor()
+	t.RegisterTool(tools.NewBashTool(executor))
+	t.RegisterTool(tools.NewKubectlTool(executor))
+
 	s := &kubectlMCPServer{
 		kubectlConfig: kubectlConfig,
 		workDir:       workDir,
@@ -45,7 +52,7 @@ func newKubectlMCPServer(ctx context.Context, kubectlConfig string, tools tools.
 			"0.0.1",
 			server.WithToolCapabilities(true),
 		),
-		tools:         tools,
+		tools:         t,
 		mcpServerMode: serverMode,
 		httpPort:      httpPort,
 	}


### PR DESCRIPTION
## Summary

- **Bug:** Running `kubectl-ai --mcp-server` exposes zero tools to MCP clients because the built-in `bash` and `kubectl` tools are never registered in the MCP server path.
- **Root cause:** `tools.Default()` returns an empty map. The built-in tools are only registered during agent conversation initialization (`conversation.go:286-287`), which the MCP server path bypasses entirely.
- **Fix:** Explicitly create a `LocalExecutor` and register `NewBashTool` and `NewKubectlTool` in `newKubectlMCPServer` before adding them to the MCP server.

## Test plan

- [x] `go build` succeeds
- [x] `go test ./cmd/ -run MCP -v` passes — now returns 3 tools (bash, kubectl, stub) instead of just 1 (stub)
- [x] Manual: `echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}' | kubectl-ai --mcp-server` followed by `tools/list` returns bash and kubectl tools
- [x] Manual: Claude Desktop config with `kubectl-ai --mcp-server` shows tools available