### PR TITLE
ollama: implement streaming and plain-text ReAct fallback

### DIFF
--- a/gollm/ollama.go
+++ b/gollm/ollama.go
@@ -201,12 +201,82 @@ func (c *OllamaChat) IsRetryableError(err error) bool {
 }
 
 func (c *OllamaChat) SendStreaming(ctx context.Context, contents ...any) (ChatResponseIterator, error) {
-	// TODO: Implement streaming
-	response, err := c.Send(ctx, contents...)
-	if err != nil {
-		return nil, err
+	log := klog.FromContext(ctx)
+
+	for _, content := range contents {
+		switch v := content.(type) {
+		case string:
+			c.history = append(c.history, api.Message{Role: "user", Content: v})
+		case FunctionCallResult:
+			c.history = append(c.history, api.Message{
+				Role:    "user",
+				Content: fmt.Sprintf("Function call result: %s", v.Result),
+			})
+		default:
+			return nil, fmt.Errorf("unsupported content type: %T", v)
+		}
 	}
-	return singletonChatResponseIterator(response), nil
+
+	req := &api.ChatRequest{
+		Model:    c.model,
+		Messages: c.history,
+		Stream:   ptrTo(true),
+		Tools:    c.tools,
+	}
+
+	iterator := func(yield func(ChatResponse, error) bool) {
+		var accumulated string
+		var lastToolCalls []api.ToolCall
+
+		respFunc := func(resp api.ChatResponse) error {
+			log.V(4).Info("received streaming chunk from ollama", "content", resp.Message.Content, "done", resp.Done)
+
+			if len(resp.Message.ToolCalls) > 0 {
+				lastToolCalls = resp.Message.ToolCalls
+			}
+
+			if resp.Message.Content != "" {
+				accumulated += resp.Message.Content
+				chunk := &OllamaChatResponse{
+					ollamaResponse: resp,
+					candidates: []*OllamaCandidate{
+						{parts: []OllamaPart{{text: resp.Message.Content}}},
+					},
+				}
+				if !yield(chunk, nil) {
+					return fmt.Errorf("iterator stopped")
+				}
+			}
+
+			if resp.Done {
+				// Append the complete message to history
+				finalMsg := api.Message{
+					Role:      "assistant",
+					Content:   accumulated,
+					ToolCalls: lastToolCalls,
+				}
+				c.history = append(c.history, finalMsg)
+
+				// If there are tool calls, yield them as a final response
+				if len(lastToolCalls) > 0 {
+					toolResp := &OllamaChatResponse{
+						ollamaResponse: resp,
+						candidates: []*OllamaCandidate{
+							{parts: []OllamaPart{{toolCalls: lastToolCalls}}},
+						},
+					}
+					yield(toolResp, nil)
+				}
+			}
+			return nil
+		}
+
+		if err := c.client.Chat(ctx, req, respFunc); err != nil {
+			yield(nil, err)
+		}
+	}
+
+	return iterator, nil
 }
 
 func (c *OllamaChat) Initialize(messages []*kctlApi.Message) error {

--- a/pkg/agent/conversation.go
+++ b/pkg/agent/conversation.go
@@ -1309,7 +1309,14 @@ func extractJSON(s string) (string, bool) {
 func parseReActResponse(input string) (*ReActResponse, error) {
 	cleaned, found := extractJSON(input)
 	if !found {
-		return nil, fmt.Errorf("no JSON code block found in %q", cleaned)
+		trimmed := strings.TrimSpace(input)
+		if trimmed == "" {
+			return nil, fmt.Errorf("no JSON code block found in empty response")
+		}
+
+		// Some models return plain text even when instructed to emit JSON.
+		// Treat this as a final answer instead of failing hard.
+		return &ReActResponse{Answer: trimmed}, nil
 	}
 
 	cleaned = strings.ReplaceAll(cleaned, "\n", "")

--- a/pkg/agent/conversation_test.go
+++ b/pkg/agent/conversation_test.go
@@ -404,3 +404,33 @@ func TestAgent_NewSession_NoDeadlock(t *testing.T) {
 		t.Fatal("NewSession timed out (potential deadlock)")
 	}
 }
+
+func TestParseReActResponse_JSONBlock(t *testing.T) {
+	input := "```json\n{\"thought\":\"check pods\",\"action\":{\"name\":\"kubectl\",\"reason\":\"list pods\",\"command\":\"kubectl get pods -A\",\"modifies_resource\":\"no\"}}\n```"
+
+	got, err := parseReActResponse(input)
+	if err != nil {
+		t.Fatalf("parseReActResponse returned error: %v", err)
+	}
+	if got.Action == nil {
+		t.Fatalf("expected action to be parsed")
+	}
+	if got.Action.Name != "kubectl" {
+		t.Fatalf("expected action name kubectl, got %q", got.Action.Name)
+	}
+}
+
+func TestParseReActResponse_PlainTextFallback(t *testing.T) {
+	input := "The command was executed successfully. Pods are healthy."
+
+	got, err := parseReActResponse(input)
+	if err != nil {
+		t.Fatalf("parseReActResponse returned error: %v", err)
+	}
+	if got.Answer != input {
+		t.Fatalf("expected answer %q, got %q", input, got.Answer)
+	}
+	if got.Action != nil {
+		t.Fatalf("expected nil action for plain text fallback")
+	}
+}


### PR DESCRIPTION
- Implement real streaming in SendStreaming for Ollama provider. Previously it blocked on the full response causing context cancellation in interactive mode. Now chunks are yielded token-by-token as Ollama generates them.

- Add plain-text fallback in parseReActResponse. When a local model returns plain text instead of a JSON code block, treat it as a final answer instead of failing with 'no JSON code block found'.

- Add unit tests for both JSON and plain-text ReAct parsing paths.

Tested with qwen2.5:1.5b and qwen2.5:7b on Ollama against a k3s cluster.