### PR TITLE
fix: use user-specific cache dir for logs to avoid multi-user permiss…

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -147,6 +147,20 @@ var defaultConfigPaths = []string{
 	filepath.Join("{HOME}", ".config", "kubectl-ai", "config.yaml"),
 }
 
+// kubectlAICacheDir returns a user-specific cache directory for kubectl-ai files.
+// This avoids permission conflicts when multiple users share a system.
+func kubectlAICacheDir() string {
+	cacheDir, err := os.UserCacheDir()
+	if err != nil {
+		// Fallback: use a user-specific subdirectory under the system temp dir
+		cacheDir = filepath.Join(os.TempDir(), fmt.Sprintf("kubectl-ai-user-%d", os.Getuid()))
+	} else {
+		cacheDir = filepath.Join(cacheDir, "kubectl-ai")
+	}
+	os.MkdirAll(cacheDir, 0o700)
+	return cacheDir
+}
+
 func (o *Options) InitDefaults() {
 	o.ProviderID = "gemini"
 	o.ModelID = "gemini-2.5-pro"
@@ -165,7 +179,7 @@ func (o *Options) InitDefaults() {
 	o.KubeConfigPath = ""
 	o.PromptTemplateFilePath = ""
 	o.ExtraPromptPaths = []string{}
-	o.TracePath = filepath.Join(os.TempDir(), "kubectl-ai-trace.txt")
+	o.TracePath = filepath.Join(kubectlAICacheDir(), "kubectl-ai-trace.txt")
 	o.RemoveWorkDir = false
 	o.ToolConfigPaths = defaultToolConfigPaths
 	// Default to terminal UI
@@ -271,7 +285,7 @@ func run(ctx context.Context) error {
 	klog.InitFlags(klogFlags)
 
 	klogFlags.Set("logtostderr", "false")
-	klogFlags.Set("log_file", filepath.Join(os.TempDir(), "kubectl-ai.log"))
+	klogFlags.Set("log_file", filepath.Join(kubectlAICacheDir(), "kubectl-ai.log"))
 
 	defer klog.Flush()
 
@@ -690,8 +704,8 @@ func resolveKubeConfigPath(opt *Options) error {
 }
 
 func startMCPServer(ctx context.Context, opt Options) error {
-	workDir := filepath.Join(os.TempDir(), "kubectl-ai-mcp")
-	if err := os.MkdirAll(workDir, 0o755); err != nil {
+	workDir := filepath.Join(kubectlAICacheDir(), "mcp")
+	if err := os.MkdirAll(workDir, 0o700); err != nil {
 		return fmt.Errorf("error creating work directory: %w", err)
 	}
 	mcpServer, err := newKubectlMCPServer(ctx, opt.KubeConfigPath, tools.Default(), workDir, opt.ExternalTools, opt.MCPServerMode, opt.HTTPPort)

--- a/pkg/ui/terminal.go
+++ b/pkg/ui/terminal.go
@@ -206,7 +206,15 @@ func (u *TerminalUI) readlineInstance() (*readline.Instance, error) {
 		return u.rlInstance, nil
 	}
 	// Initialize readline input
-	historyPath := filepath.Join(os.TempDir(), "kubectl-ai-history")
+	// Use a user-specific cache directory to avoid permission conflicts in multi-user environments.
+	cacheDir, err := os.UserCacheDir()
+	if err != nil {
+		cacheDir = filepath.Join(os.TempDir(), fmt.Sprintf("kubectl-ai-user-%d", os.Getuid()))
+	} else {
+		cacheDir = filepath.Join(cacheDir, "kubectl-ai")
+	}
+	os.MkdirAll(cacheDir, 0o700)
+	historyPath := filepath.Join(cacheDir, "kubectl-ai-history")
 	rl, err := readline.NewEx(&readline.Config{
 		Prompt:      ">>> ", // Default prompt for main input
 		Stdin:       os.Stdin,


### PR DESCRIPTION
…ion conflicts (#564)

Previously, kubectl-ai stored log files, trace files, readline history, and MCP work directories under /tmp/ with restrictive permissions (0644). When multiple users shared a system, the first user's files blocked others.

Fix: Replace shared /tmp paths with per-user cache directories using os.UserCacheDir() (~/.cache/kubectl-ai/), with a fallback to a user-specific temp dir. Directories are created with 0700 permissions.

Fixes #564