### PR TITLE
fix: add kubectl prefix when LLM omits it from commands (#274)

### DIFF
--- a/pkg/tools/kubectl_tool.go
+++ b/pkg/tools/kubectl_tool.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/kubectl-ai/gollm"
 	"github.com/GoogleCloudPlatform/kubectl-ai/pkg/sandbox"
+	"mvdan.cc/sh/v3/syntax"
 )
 
 type Kubectl struct {
@@ -117,6 +118,9 @@ func (t *Kubectl) Run(ctx context.Context, args map[string]any) (any, error) {
 		return &sandbox.ExecResult{Command: command, Error: err.Error()}, nil
 	}
 
+	// Ensure kubectl prefix is present (LLMs sometimes omit it)
+	command = ensureKubectlPrefix(command)
+
 	// Prepare environment
 	env := os.Environ()
 	if kubeconfig != "" {
@@ -172,6 +176,36 @@ func (t *Kubectl) CheckModifiesResource(args map[string]any) string {
 	}
 
 	return kubectlModifiesResource(command)
+}
+
+// ensureKubectlPrefix adds the "kubectl" prefix to a command if it's missing.
+// It only adds the prefix for simple commands (no pipes, redirects, etc.).
+func ensureKubectlPrefix(command string) string {
+	if strings.HasPrefix(command, "kubectl ") || strings.HasPrefix(command, "kubectl\n") || command == "kubectl" {
+		return command
+	}
+
+	// Parse the command to check if it's a simple command
+	parser := syntax.NewParser()
+	prog, err := parser.Parse(strings.NewReader(command), "")
+	if err != nil {
+		// If we can't parse it, just prepend kubectl
+		return "kubectl " + command
+	}
+
+	// Only prepend for simple commands (no pipes, redirects, etc.)
+	if len(prog.Stmts) != 1 {
+		return command
+	}
+	stmt := prog.Stmts[0]
+	if stmt.Background || stmt.Coprocess || stmt.Negated || len(stmt.Redirs) > 0 {
+		return command
+	}
+	if _, ok := stmt.Cmd.(*syntax.CallExpr); !ok {
+		return command
+	}
+
+	return "kubectl " + command
 }
 
 func validateKubectlCommand(command string) error {

--- a/pkg/tools/kubectl_tool_test.go
+++ b/pkg/tools/kubectl_tool_test.go
@@ -1,0 +1,80 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tools
+
+import "testing"
+
+func TestEnsureKubectlPrefix(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "already has kubectl prefix",
+			input:    "kubectl get pods",
+			expected: "kubectl get pods",
+		},
+		{
+			name:     "missing kubectl prefix",
+			input:    "get pods",
+			expected: "kubectl get pods",
+		},
+		{
+			name:     "missing prefix with flags",
+			input:    "get pods -n default",
+			expected: "kubectl get pods -n default",
+		},
+		{
+			name:     "missing prefix describe",
+			input:    "describe pod my-pod",
+			expected: "kubectl describe pod my-pod",
+		},
+		{
+			name:     "already has prefix with namespace",
+			input:    "kubectl get pods -n kube-system",
+			expected: "kubectl get pods -n kube-system",
+		},
+		{
+			name:     "pipe command left unchanged",
+			input:    "get pods | grep Running",
+			expected: "get pods | grep Running",
+		},
+		{
+			name:     "kubectl with pipe left unchanged",
+			input:    "kubectl get pods | grep Running",
+			expected: "kubectl get pods | grep Running",
+		},
+		{
+			name:     "just kubectl",
+			input:    "kubectl",
+			expected: "kubectl",
+		},
+		{
+			name:     "apply with file",
+			input:    "apply -f deployment.yaml",
+			expected: "kubectl apply -f deployment.yaml",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ensureKubectlPrefix(tt.input)
+			if result != tt.expected {
+				t.Errorf("ensureKubectlPrefix(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
LLMs sometimes generate commands like 'get pods' instead of 'kubectl get pods'. The KubectlTool now ensures the prefix is present using ensureKubectlPrefix(), which parses the command with a shell parser and only prepends 'kubectl' for simple commands (no pipes or redirects). This follows the same pattern as CustomTool.addCommandPrefix().

Added unit tests covering prefix addition, already-prefixed commands, and complex commands that should be left unchanged.

Fixes #274