### PR TITLE
fix: prevent token limit errors from large kubectl logs output (#249)

### DIFF
--- a/pkg/tools/kubectl_tool.go
+++ b/pkg/tools/kubectl_tool.go
@@ -117,6 +117,9 @@ func (t *Kubectl) Run(ctx context.Context, args map[string]any) (any, error) {
 		return &sandbox.ExecResult{Command: command, Error: err.Error()}, nil
 	}
 
+	// Auto-limit kubectl logs output to prevent token limit errors
+	command = addDefaultTailForLogs(command)
+
 	// Prepare environment
 	env := os.Environ()
 	if kubeconfig != "" {
@@ -172,6 +175,20 @@ func (t *Kubectl) CheckModifiesResource(args map[string]any) string {
 	}
 
 	return kubectlModifiesResource(command)
+}
+
+// addDefaultTailForLogs adds --tail=500 to kubectl logs commands that don't
+// already specify a --tail flag or --since flag. This prevents unbounded log
+// output from exceeding LLM token limits.
+func addDefaultTailForLogs(command string) string {
+	if !strings.Contains(command, " logs ") && !strings.Contains(command, " logs\n") {
+		return command
+	}
+	// Don't add --tail if already specified or if --since is used
+	if strings.Contains(command, "--tail") || strings.Contains(command, "--since") {
+		return command
+	}
+	return command + " --tail=500"
 }
 
 func validateKubectlCommand(command string) error {

--- a/pkg/tools/kubectl_tool_test.go
+++ b/pkg/tools/kubectl_tool_test.go
@@ -1,0 +1,65 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tools
+
+import "testing"
+
+func TestAddDefaultTailForLogs(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "kubectl logs without tail",
+			input:    "kubectl logs my-pod",
+			expected: "kubectl logs my-pod --tail=500",
+		},
+		{
+			name:     "kubectl logs already has tail",
+			input:    "kubectl logs my-pod --tail=100",
+			expected: "kubectl logs my-pod --tail=100",
+		},
+		{
+			name:     "kubectl logs with --since",
+			input:    "kubectl logs my-pod --since=1h",
+			expected: "kubectl logs my-pod --since=1h",
+		},
+		{
+			name:     "kubectl logs -f (streaming)",
+			input:    "kubectl logs my-pod -f",
+			expected: "kubectl logs my-pod -f --tail=500",
+		},
+		{
+			name:     "not a logs command",
+			input:    "kubectl get pods",
+			expected: "kubectl get pods",
+		},
+		{
+			name:     "logs with namespace",
+			input:    "kubectl logs my-pod -n production",
+			expected: "kubectl logs my-pod -n production --tail=500",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := addDefaultTailForLogs(tt.input)
+			if result != tt.expected {
+				t.Errorf("addDefaultTailForLogs(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}

--- a/pkg/tools/tools.go
+++ b/pkg/tools/tools.go
@@ -231,16 +231,34 @@ func (t *ToolCall) InvokeTool(ctx context.Context, opt InvokeToolOptions) (any, 
 	return response, err
 }
 
+// maxOutputBytes is the maximum size of stdout/stderr output that will be
+// sent to the LLM. Larger outputs are truncated to avoid exceeding token limits.
+const maxOutputBytes = 16384 // 16KB
+
+// truncateOutput truncates s to maxOutputBytes, appending a note if truncated.
+func truncateOutput(s string) string {
+	if len(s) <= maxOutputBytes {
+		return s
+	}
+	return s[:maxOutputBytes] + fmt.Sprintf("\n... [output truncated: showing %d of %d bytes]", maxOutputBytes, len(s))
+}
+
 // ToolResultToMap converts an arbitrary result to a map[string]any
 func ToolResultToMap(result any) (map[string]any, error) {
 	// Handle simple string results (common with MCP tools)
 	if str, ok := result.(string); ok {
-		return map[string]any{"content": str}, nil
+		return map[string]any{"content": truncateOutput(str)}, nil
 	}
 
 	// Handle nil results
 	if result == nil {
 		return map[string]any{"content": ""}, nil
+	}
+
+	// Truncate large ExecResult outputs before converting
+	if execResult, ok := result.(*sandbox.ExecResult); ok && execResult != nil {
+		execResult.Stdout = truncateOutput(execResult.Stdout)
+		execResult.Stderr = truncateOutput(execResult.Stderr)
 	}
 
 	// Try to convert to map via JSON for structured results


### PR DESCRIPTION
Two changes to prevent LLM token limit errors when fetching pod logs:

1. Auto-add --tail=500 to kubectl logs commands that don't already specify --tail or --since, preventing unbounded log output.

2. Truncate tool output (stdout/stderr) to 16KB in ToolResultToMap() before sending to the LLM. This is a safety net for any command that produces unexpectedly large output, with a clear truncation indicator appended.

Fixes #249