### PR TITLE
fix: set COLUMNS env for kubectl wide output (#445)

### DIFF
--- a/pkg/tools/kubectl_tool.go
+++ b/pkg/tools/kubectl_tool.go
@@ -127,6 +127,10 @@ func (t *Kubectl) Run(ctx context.Context, args map[string]any) (any, error) {
 		env = append(env, "KUBECONFIG="+kubeconfig)
 	}
 
+	// Set a wide column width so kubectl tabular output (especially -o wide)
+	// is not truncated in the non-TTY execution environment.
+	env = append(env, "COLUMNS=256")
+
 	return ExecuteWithStreamingHandling(ctx, t.executor, command, workDir, env, DetectKubectlStreaming)
 }
 

--- a/pkg/tools/kubectl_tool_test.go
+++ b/pkg/tools/kubectl_tool_test.go
@@ -1,0 +1,75 @@
+package tools
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/kubectl-ai/pkg/sandbox"
+)
+
+// envCapturingExecutor captures the env passed to Execute.
+type envCapturingExecutor struct {
+	capturedEnv []string
+}
+
+func (e *envCapturingExecutor) Execute(ctx context.Context, command string, env []string, workDir string) (*sandbox.ExecResult, error) {
+	e.capturedEnv = env
+	return &sandbox.ExecResult{Command: command, Stdout: "ok"}, nil
+}
+
+func (e *envCapturingExecutor) Close(ctx context.Context) error { return nil }
+
+func TestKubectlRunSetsColumnsEnv(t *testing.T) {
+	executor := &envCapturingExecutor{}
+	tool := &Kubectl{executor: executor}
+
+	ctx := context.WithValue(context.Background(), KubeconfigKey, "")
+	ctx = context.WithValue(ctx, WorkDirKey, "/tmp")
+
+	_, err := tool.Run(ctx, map[string]any{"command": "kubectl get nodes -o wide"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	found := false
+	for _, env := range executor.capturedEnv {
+		if env == "COLUMNS=256" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("COLUMNS=256 not found in env passed to executor; env = %v", executor.capturedEnv)
+	}
+}
+
+func TestKubectlRunSetsColumnsWithKubeconfig(t *testing.T) {
+	executor := &envCapturingExecutor{}
+	tool := &Kubectl{executor: executor}
+
+	ctx := context.WithValue(context.Background(), KubeconfigKey, "/home/user/.kube/config")
+	ctx = context.WithValue(ctx, WorkDirKey, "/tmp")
+
+	_, err := tool.Run(ctx, map[string]any{"command": "kubectl get pods"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	hasColumns := false
+	hasKubeconfig := false
+	for _, env := range executor.capturedEnv {
+		if env == "COLUMNS=256" {
+			hasColumns = true
+		}
+		if strings.HasPrefix(env, "KUBECONFIG=") {
+			hasKubeconfig = true
+		}
+	}
+	if !hasColumns {
+		t.Error("COLUMNS=256 not found in env")
+	}
+	if !hasKubeconfig {
+		t.Error("KUBECONFIG not found in env")
+	}
+}


### PR DESCRIPTION
Root cause: When kubectl runs without a TTY (i.e., via exec.Command() in Go), it defaults to 80-column output. The -o wide flag shows extra columns (IP, OS, kernel, etc.), but they get truncated because 80 columns isn't enough. This happens regardless of which model is used.

Fix: Set COLUMNS=256 in the environment when executing kubectl commands, matching what a typical terminal would provide.

Note: This is not a model quality issue — even frontier models return truncated output because kubectl itself truncates before the output reaches the LLM.