### PR TITLE
fix: report error message when LLM connection fails (#573)

### DIFF
--- a/pkg/agent/agent_e2e_test.go
+++ b/pkg/agent/agent_e2e_test.go
@@ -16,6 +16,8 @@ package agent
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -309,5 +311,78 @@ func TestAgentEndToEndMetaClear(t *testing.T) {
 	}
 	if msgs[0].Payload != "Cleared the conversation." {
 		t.Fatalf("first message after clear = %q, want %q", msgs[0].Payload, "Cleared the conversation.")
+	}
+}
+
+func TestAgentEndToEndLLMErrorReportsError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	store := sessions.NewInMemoryChatStore()
+
+	client := mocks.NewMockClient(ctrl)
+	chat := mocks.NewMockChat(ctrl)
+
+	client.EXPECT().StartChat(gomock.Any(), "test-model").Return(chat)
+	chat.EXPECT().Initialize(gomock.Any()).Return(nil)
+	chat.EXPECT().SetFunctionDefinitions(gomock.Any()).Return(nil)
+
+	// Simulate LLM connection failure
+	llmErr := fmt.Errorf("connection refused: no LLM available")
+	chat.EXPECT().SendStreaming(gomock.Any(), gomock.Any()).Return(nil, llmErr)
+
+	var toolset tools.Tools
+	toolset.Init()
+
+	a := &Agent{
+		ChatMessageStore: store,
+		LLM:              client,
+		Model:            "test-model",
+		Tools:            toolset,
+		MaxIterations:    4,
+		RunOnce:          true,
+		InitialQuery:     "fix the oomkilled pod",
+		Session: &api.Session{
+			ID:               "test-session",
+			ChatMessageStore: store,
+			AgentState:       api.AgentStateIdle,
+		},
+	}
+
+	if err := a.Init(ctx); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	if err := a.Run(ctx, "fix the oomkilled pod"); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	// The agent should emit an error message, not silently succeed
+	sawError := false
+	timeout := time.After(3 * time.Second)
+	for !sawError {
+		select {
+		case v := <-a.Output:
+			m, ok := v.(*api.Message)
+			if !ok {
+				continue
+			}
+			if m.Type == api.MessageTypeError {
+				sawError = true
+				errPayload, _ := m.Payload.(string)
+				if !strings.Contains(errPayload, "connection refused") {
+					t.Errorf("expected error message to contain 'connection refused', got %q", errPayload)
+				}
+			}
+		case <-timeout:
+			t.Fatalf("timed out waiting for error message; agent silently swallowed LLM error")
+		}
+	}
+
+	// Verify state
+	if a.LastErr() == nil {
+		t.Error("expected LastErr to be set after LLM failure")
 	}
 }

--- a/pkg/agent/conversation.go
+++ b/pkg/agent/conversation.go
@@ -603,6 +603,7 @@ func (c *Agent) Run(ctx context.Context, initialQuery string) error {
 					log.Error(err, "error sending streaming LLM response")
 					c.setAgentState(api.AgentStateDone)
 					c.pendingFunctionCalls = []ToolCallAnalysis{}
+					c.addMessage(api.MessageSourceAgent, api.MessageTypeError, "Error: "+err.Error())
 					c.lastErr = err
 					continue
 				}
@@ -616,6 +617,8 @@ func (c *Agent) Run(ctx context.Context, initialQuery string) error {
 					if err != nil {
 						c.setAgentState(api.AgentStateDone)
 						c.pendingFunctionCalls = []ToolCallAnalysis{}
+						c.addMessage(api.MessageSourceAgent, api.MessageTypeError, "Error: "+err.Error())
+						c.lastErr = err
 
 						// In RunOnce mode, exit on shim conversion error
 						if c.RunOnce {


### PR DESCRIPTION
Two error paths in the agentic loop silently set state to Done without emitting an error message: SendStreaming failure and shim conversion error. This caused eval tests (like fix-oomkilled) to pass with false positives when no LLM was available — the agent appeared to succeed despite never making any tool calls.

Fix: add c.addMessage() error reporting and c.lastErr assignment to both error paths, matching the pattern used by all other error handlers in the loop.