### PR TITLE
fix(mcp): bind streamable-http listener to loopback by default

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -100,6 +100,10 @@ type Options struct {
 	MCPServerMode string `json:"mcpServerMode,omitempty"`
 	// Set the HTTP endpoint port for the MCP server when using HTTP transports like streamable-http.
 	HTTPPort int `json:"httpPort,omitempty"`
+	// MCPHTTPBindAddress is the host the MCP server listens on when using HTTP
+	// transports. Defaults to 127.0.0.1 because the MCP HTTP endpoint exposes the
+	// built-in `bash` and `kubectl` tools without authentication.
+	MCPHTTPBindAddress string `json:"mcpHTTPBindAddress,omitempty"`
 	// KubeConfigPath is the path to the kubeconfig file.
 	// If not provided, the default kubeconfig path will be used.
 	KubeConfigPath string `json:"kubeConfigPath,omitempty"`
@@ -178,6 +182,7 @@ func (o *Options) InitDefaults() {
 	o.MCPServerMode = "stdio"
 	// Default port for HTTP endpoint when using streamable-http mode
 	o.HTTPPort = 9080
+	o.MCPHTTPBindAddress = "127.0.0.1"
 
 	// Session management options
 	o.ResumeSession = ""
@@ -321,6 +326,7 @@ func (opt *Options) bindCLIFlags(f *pflag.FlagSet) error {
 	f.BoolVar(&opt.MCPClient, "mcp-client", opt.MCPClient, "enable MCP client mode to connect to external MCP servers")
 	f.StringVar(&opt.MCPServerMode, "mcp-server-mode", opt.MCPServerMode, "mode of the MCP server. Supported values: stdio, streamable-http")
 	f.IntVar(&opt.HTTPPort, "http-port", opt.HTTPPort, "port for the HTTP endpoint in MCP server mode (used with --mcp-server when --mcp-server-mode is streamable-http)")
+	f.StringVar(&opt.MCPHTTPBindAddress, "mcp-http-bind-address", opt.MCPHTTPBindAddress, "host the MCP HTTP server binds to. Defaults to 127.0.0.1 because the endpoint exposes the built-in bash and kubectl tools without authentication; set explicitly (e.g. 0.0.0.0) only after putting auth/firewall in front")
 	f.BoolVar(&opt.EnableToolUseShim, "enable-tool-use-shim", opt.EnableToolUseShim, "enable tool use shim")
 	f.BoolVar(&opt.Quiet, "quiet", opt.Quiet, "run in non-interactive mode, requires a query to be provided as a positional argument")
 
@@ -694,7 +700,7 @@ func startMCPServer(ctx context.Context, opt Options) error {
 	if err := os.MkdirAll(workDir, 0o755); err != nil {
 		return fmt.Errorf("error creating work directory: %w", err)
 	}
-	mcpServer, err := newKubectlMCPServer(ctx, opt.KubeConfigPath, tools.Default(), workDir, opt.ExternalTools, opt.MCPServerMode, opt.HTTPPort)
+	mcpServer, err := newKubectlMCPServer(ctx, opt.KubeConfigPath, tools.Default(), workDir, opt.ExternalTools, opt.MCPServerMode, opt.MCPHTTPBindAddress, opt.HTTPPort)
 	if err != nil {
 		return fmt.Errorf("creating mcp server: %w", err)
 	}

--- a/cmd/mcp.go
+++ b/cmd/mcp.go
@@ -34,10 +34,11 @@ type kubectlMCPServer struct {
 	workDir       string
 	mcpManager    *mcp.Manager // Add MCP manager for external tool calls
 	mcpServerMode string       // Server mode (e.g., "streamable-http", "stdio")
+	httpHost      string       // Bind host for HTTP-based server modes
 	httpPort      int          // Port for HTTP-based server modes
 }
 
-func newKubectlMCPServer(ctx context.Context, kubectlConfig string, t tools.Tools, workDir string, exposeExternalTools bool, serverMode string, httpPort int) (*kubectlMCPServer, error) {
+func newKubectlMCPServer(ctx context.Context, kubectlConfig string, t tools.Tools, workDir string, exposeExternalTools bool, serverMode string, httpHost string, httpPort int) (*kubectlMCPServer, error) {
 	// Register built-in tools (bash and kubectl) which require an executor.
 	// In MCP server mode, we use a local executor since there's no sandbox.
 	executor := sandbox.NewLocalExecutor()
@@ -54,6 +55,7 @@ func newKubectlMCPServer(ctx context.Context, kubectlConfig string, t tools.Tool
 		),
 		tools:         t,
 		mcpServerMode: serverMode,
+		httpHost:      httpHost,
 		httpPort:      httpPort,
 	}
 
@@ -172,11 +174,26 @@ func (s *kubectlMCPServer) Serve(ctx context.Context) error {
 
 	switch s.mcpServerMode {
 	case "streamable-http":
-		// Start the server in streamable HTTP mode
-		klog.Infof("Starting MCP server in streamable HTTP mode on port %d", s.httpPort)
+		// Start the server in streamable HTTP mode.
+		//
+		// The MCP HTTP transport exposes the built-in `bash` and `kubectl`
+		// tools to any caller that can reach the listener and supply a
+		// session id; there is no auth on this port. We therefore default
+		// the bind host to loopback so a Cloud Build / coffee-shop /
+		// shared-cluster neighbour cannot reach the listener. Operators
+		// that intentionally want a remote listener can opt in with
+		// --mcp-http-bind-address=0.0.0.0 (and should put their own
+		// authentication / firewall in front of it).
+		host := s.httpHost
+		if host == "" {
+			host = "127.0.0.1"
+		}
+		if host == "0.0.0.0" || host == "::" {
+			klog.Warningf("MCP HTTP server bound to %s -- the bash and kubectl tools are reachable to anyone on the network; put authentication in front of this port", host)
+		}
+		endpoint := fmt.Sprintf("%s:%d", host, s.httpPort)
+		klog.Infof("Starting MCP server in streamable HTTP mode on %s", endpoint)
 		httpServer := server.NewStreamableHTTPServer(s.server)
-		endpoint := fmt.Sprintf(":%d", s.httpPort)
-		klog.Infof("Listening for streamable HTTP connections on port %d", s.httpPort)
 		return httpServer.Start(endpoint)
 	default:
 		return server.ServeStdio(s.server)


### PR DESCRIPTION
## Summary

`cmd/mcp.go:178` formats the streamable-http listener endpoint as `:%d`, which causes Go's `net.Listen` to bind on all interfaces. The same code path registers the built-in `bash` and `kubectl` tools and dispatches calls to them with **no authentication, no Origin check, and no Host validation** (`handleBuiltinToolCall` invokes `tool.Run(ctx, args)` directly).

The documented setup in `docs/mcp-server.md:34` says *"This listens on http://localhost:9080/mcp by default"*, so users reasonably expect a loopback-only listener. In practice anyone on the same LAN (or the rest of a shared Cloud Build / coffee-shop / multi-tenant VM) can call the `bash` tool to run arbitrary shell as the running user, or the `kubectl` tool to read every Secret, ConfigMap and pod env in the user's configured clusters. A browser-driven DNS-rebinding attack can do the same against a single-user workstation that intends to use only loopback.

I verified locally on `v0.0.31` (`08cf256`):

```
$ kubectl-ai --mcp-server --mcp-server-mode streamable-http --http-port 19080
$ lsof -i :19080
COMMAND    PID USER FD TYPE DEVICE SIZE/OFF NODE NAME
kubectl-a 41136 end  7u IPv6 ...      0t0   TCP *:19080 (LISTEN)
```

Note `*:19080`, not `localhost:19080`. Unauthenticated `POST /mcp` with `{"jsonrpc":"2.0","method":"tools/call","params":{"name":"bash","arguments":{"command":"id; cat /etc/passwd"}}}` from any LAN host returns the command output.

## Fix

Introduce `--mcp-http-bind-address`, defaulting to `127.0.0.1`. The default forces a loopback bind which matches the documentation. Operators who intentionally want a remote listener can opt in with `--mcp-http-bind-address=0.0.0.0` (or any specific address); that mode emits a `klog.Warningf` so it is obvious in the build/CI logs that an unauth-able port is reachable from the network.

## Test plan

Local verification with the patched binary:

- [x] Default: `lsof -i :19183` shows `kubectl-a ... TCP localhost:19183 (LISTEN)` (loopback only).
- [x] `--mcp-http-bind-address 0.0.0.0` → `TCP *:19184 (LISTEN)` plus a warning log.
- [x] Build clean with `GOWORK=off go build -o /tmp/kubectl-ai-test ./cmd/`.

Future work happy to follow up with in a separate PR: optional bearer-token auth on the HTTP endpoint, Origin/Host allowlist for DNS-rebinding resistance, and routing built-in tool calls through the same approval/modifies_resource gate that protects the CLI/UI agent path.