### PR TITLE
feat: add suggest-only mode

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -84,6 +84,8 @@ type Options struct {
 	// SkipPermissions is a flag to skip asking for confirmation before executing kubectl commands
 	// that modifies resources in the cluster.
 	SkipPermissions bool `json:"skipPermissions,omitempty"`
+	// SuggestOnly skips execution of tool calls that would modify resources.
+	SuggestOnly bool `json:"suggestOnly,omitempty"`
 	// EnableToolUseShim is a flag to enable tool use shim.
 	// TODO(droot): figure out a better way to discover if the model supports tool use
 	// and set this automatically.
@@ -315,6 +317,7 @@ func (opt *Options) bindCLIFlags(f *pflag.FlagSet) error {
 	f.StringVar(&opt.ProviderID, "llm-provider", opt.ProviderID, "language model provider")
 	f.StringVar(&opt.ModelID, "model", opt.ModelID, "language model e.g. gemini-2.0-flash-thinking-exp-01-21, gemini-2.0-flash")
 	f.BoolVar(&opt.SkipPermissions, "skip-permissions", opt.SkipPermissions, "(dangerous) skip asking for confirmation before executing kubectl commands that modify resources")
+	f.BoolVar(&opt.SuggestOnly, "suggest-only", opt.SuggestOnly, "show suggested changes without executing tool calls that modify resources")
 	f.BoolVar(&opt.MCPServer, "mcp-server", opt.MCPServer, "run in MCP server mode")
 	f.BoolVar(&opt.ExternalTools, "external-tools", opt.ExternalTools, "in MCP server mode, discover and expose external MCP tools")
 	f.StringArrayVar(&opt.ToolConfigPaths, "custom-tools-config", opt.ToolConfigPaths, "path to custom tools config file or directory")
@@ -445,6 +448,7 @@ func RunRootCommand(ctx context.Context, opt Options, args []string) error {
 			Recorder:           recorder,
 			RemoveWorkDir:      opt.RemoveWorkDir,
 			SkipPermissions:    opt.SkipPermissions,
+			SuggestOnly:        opt.SuggestOnly,
 			EnableToolUseShim:  opt.EnableToolUseShim,
 			MCPClientEnabled:   opt.MCPClient,
 			Sandbox:            opt.Sandbox,

--- a/pkg/agent/agent_e2e_test.go
+++ b/pkg/agent/agent_e2e_test.go
@@ -16,6 +16,8 @@ package agent
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -224,6 +226,95 @@ func TestAgentEndToEndToolExecution(t *testing.T) {
 	default:
 		if st := a.AgentState(); st != api.AgentStateDone && st != api.AgentStateWaitingForInput {
 			t.Fatalf("unexpected state after tool run: %s (want Done or WaitingForInput)", st)
+		}
+	}
+}
+
+func TestAgentSuggestOnlySkipsMutatingTool(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	store := sessions.NewInMemoryChatStore()
+	client := mocks.NewMockClient(ctrl)
+	chat := mocks.NewMockChat(ctrl)
+
+	client.EXPECT().StartChat(gomock.Any(), "test-model").Return(chat)
+	chat.EXPECT().Initialize(gomock.Any()).Return(nil)
+	chat.EXPECT().SetFunctionDefinitions(gomock.Any()).Return(nil)
+
+	firstResp := chatWith(fCalls("mocktool", map[string]any{"command": "apply"}))
+	secondResp := chatWith(fText("suggested manifest"))
+	firstIter := gollm.ChatResponseIterator(func(yield func(gollm.ChatResponse, error) bool) {
+		yield(firstResp, nil)
+	})
+	secondIter := gollm.ChatResponseIterator(func(yield func(gollm.ChatResponse, error) bool) {
+		yield(secondResp, nil)
+	})
+	gomock.InOrder(
+		chat.EXPECT().SendStreaming(gomock.Any(), gomock.Any()).Return(firstIter, nil),
+		chat.EXPECT().SendStreaming(gomock.Any(), gomock.Any()).Return(secondIter, nil),
+	)
+
+	tool := mocks.NewMockTool(ctrl)
+	tool.EXPECT().Name().Return("mocktool").AnyTimes()
+	tool.EXPECT().Description().Return("mock tool").AnyTimes()
+	tool.EXPECT().FunctionDefinition().Return(&gollm.FunctionDefinition{Name: "mocktool"}).AnyTimes()
+	tool.EXPECT().IsInteractive(gomock.Any()).Return(false, nil).AnyTimes()
+	tool.EXPECT().CheckModifiesResource(gomock.Any()).Return("yes").AnyTimes()
+
+	var toolset tools.Tools
+	toolset.Init()
+	toolset.RegisterTool(tool)
+
+	a := &Agent{
+		ChatMessageStore: store,
+		LLM:              client,
+		Model:            "test-model",
+		Tools:            toolset,
+		MaxIterations:    4,
+		SuggestOnly:      true,
+		Session: &api.Session{
+			ID:               "test-session",
+			ChatMessageStore: store,
+			AgentState:       api.AgentStateIdle,
+		},
+	}
+
+	if err := a.Init(ctx); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	if err := a.Run(ctx, ""); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	if m := recvMsg(t, ctx, a.Output); m.Type != api.MessageTypeUserInputRequest {
+		t.Fatalf("expected user-input-request, got %v", m.Type)
+	}
+	a.Input <- &api.UserInputResponse{Query: "test"}
+
+	sawSkip, sawFinal := false, false
+	for !(sawSkip && sawFinal) {
+		select {
+		case v := <-a.Output:
+			m, ok := v.(*api.Message)
+			if !ok {
+				t.Fatalf("expected *api.Message on output, got %T", v)
+			}
+			if m.Type == api.MessageTypeUserChoiceRequest || m.Type == api.MessageTypeToolCallRequest {
+				t.Fatalf("suggest-only should not request approval or execute tools, got %v", m.Type)
+			}
+			if m.Type == api.MessageTypeText && m.Source == api.MessageSourceAgent &&
+				strings.Contains(fmt.Sprint(m.Payload), "Suggest-only mode skipped execution") {
+				sawSkip = true
+			}
+			if m.Type == api.MessageTypeText && m.Source == api.MessageSourceModel {
+				sawFinal = true
+			}
+		case <-ctx.Done():
+			t.Fatalf("timeout waiting for suggest-only skip and final response")
 		}
 	}
 }

--- a/pkg/agent/conversation.go
+++ b/pkg/agent/conversation.go
@@ -93,6 +93,7 @@ type Agent struct {
 	SandboxImage string
 
 	SkipPermissions bool
+	SuggestOnly     bool
 
 	Tools tools.Tools
 
@@ -754,6 +755,13 @@ func (c *Agent) Run(ctx context.Context, initialQuery string) error {
 					continue // Skip execution for interactive commands
 				}
 
+				if c.SuggestOnly && modifiesResourceToolCallIndex >= 0 {
+					c.skipSuggestedToolCalls()
+					c.pendingFunctionCalls = []ToolCallAnalysis{}
+					c.currIteration = c.currIteration + 1
+					continue
+				}
+
 				if !c.SkipPermissions && modifiesResourceToolCallIndex >= 0 {
 					// In RunOnce mode, exit with error if permission is required
 					if c.RunOnce {
@@ -812,6 +820,30 @@ func (c *Agent) Run(ctx context.Context, initialQuery string) error {
 	}()
 
 	return nil
+}
+
+func (c *Agent) skipSuggestedToolCalls() {
+	var commandDescriptions []string
+	for _, call := range c.pendingFunctionCalls {
+		commandDescriptions = append(commandDescriptions, call.ParsedToolCall.Description())
+		result := map[string]any{
+			"error":     "Suggest-only mode is enabled; tool execution was skipped.",
+			"status":    "skipped",
+			"retryable": false,
+		}
+		if c.EnableToolUseShim {
+			c.currChatContent = append(c.currChatContent, fmt.Sprintf("Result of running %q:\n%v",
+				call.FunctionCall.Name, result["error"]))
+			continue
+		}
+		c.currChatContent = append(c.currChatContent, gollm.FunctionCallResult{
+			ID:     call.FunctionCall.ID,
+			Name:   call.FunctionCall.Name,
+			Result: result,
+		})
+	}
+	c.addMessage(api.MessageSourceAgent, api.MessageTypeText,
+		"Suggest-only mode skipped execution for:\n* "+strings.Join(commandDescriptions, "\n* "))
 }
 
 func (c *Agent) handleMetaQuery(ctx context.Context, query string) (answer string, handled bool, err error) {


### PR DESCRIPTION
## What

Adds a `--suggest-only` flag.

When enabled, kubectl-ai skips tool calls that would modify cluster resources. Instead of asking for approval or executing the command, it records the proposed action as skipped and sends that result back to the model so it can continue with a final suggestion.

Read-only tool calls can still run, so the agent can inspect the cluster before producing guidance.

## Why

Some users want kubectl-ai to help produce commands or manifests without making any changes to the cluster. Today they have to decline each proposed mutating command manually. This mode makes that workflow explicit and safer for production or GitOps-managed environments.

Fixes #628.

## Testing

- `go test ./pkg/agent -run 'TestAgentSuggestOnlySkipsMutatingTool|TestAgentEndToEndToolExecution' -count=1`
- `go test ./cmd ./pkg/agent -count=1`
- `git diff --check`
