### PR TITLE
Handle Azure OpenAI model prefixes as deployments

### DIFF
--- a/gollm/azopenai.go
+++ b/gollm/azopenai.go
@@ -106,11 +106,12 @@ func (c *AzureOpenAIClient) Close() error {
 }
 
 func (c *AzureOpenAIClient) GenerateCompletion(ctx context.Context, request *CompletionRequest) (CompletionResponse, error) {
+	deploymentName := azureOpenAIDeploymentName(request.Model)
 	req := azopenai.ChatCompletionsOptions{
 		Messages: []azopenai.ChatRequestMessageClassification{
 			&azopenai.ChatRequestUserMessage{Content: azopenai.NewChatRequestUserMessageContent(request.Prompt)},
 		},
-		DeploymentName: &request.Model,
+		DeploymentName: &deploymentName,
 	}
 
 	resp, err := c.client.GetChatCompletions(ctx, req, nil)
@@ -206,11 +207,20 @@ func (c *AzureOpenAIClient) SetResponseSchema(schema *Schema) error {
 func (c *AzureOpenAIClient) StartChat(systemPrompt string, model string) Chat {
 	return &AzureOpenAIChat{
 		client: c.client,
-		model:  model,
+		model:  azureOpenAIDeploymentName(model),
 		history: []azopenai.ChatRequestMessageClassification{
 			&azopenai.ChatRequestSystemMessage{Content: azopenai.NewChatRequestSystemMessageContent(systemPrompt)},
 		},
 	}
+}
+
+func azureOpenAIDeploymentName(model string) string {
+	for _, prefix := range []string{"azure/", "azopenai/"} {
+		if name, ok := strings.CutPrefix(model, prefix); ok {
+			return name
+		}
+	}
+	return model
 }
 
 type AzureOpenAICompletionResponse struct {

--- a/gollm/azopenai_test.go
+++ b/gollm/azopenai_test.go
@@ -1,0 +1,54 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gollm
+
+import "testing"
+
+func TestAzureOpenAIDeploymentName(t *testing.T) {
+	tests := []struct {
+		name  string
+		model string
+		want  string
+	}{
+		{
+			name:  "plain deployment",
+			model: "gpt-4.1",
+			want:  "gpt-4.1",
+		},
+		{
+			name:  "azure prefixed deployment",
+			model: "azure/gpt-4.1",
+			want:  "gpt-4.1",
+		},
+		{
+			name:  "azopenai prefixed deployment",
+			model: "azopenai/gpt-4.1",
+			want:  "gpt-4.1",
+		},
+		{
+			name:  "empty model",
+			model: "",
+			want:  "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := azureOpenAIDeploymentName(tc.model); got != tc.want {
+				t.Fatalf("azureOpenAIDeploymentName(%q) = %q, want %q", tc.model, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- normalize Azure OpenAI deployment names when the model is passed as `azure/<deployment>` or `azopenai/<deployment>`
- use the normalized deployment name for chat and completion requests
- add unit coverage for plain and prefixed deployment names

## Why
With the `azopenai` provider, a model value such as `azure/gpt-4.1` was passed directly to the Azure SDK as the deployment name. That makes the request path include `/deployments/azure/gpt-4.1/...`, which Azure reports as `DeploymentNotFound`.

Fixes #604.

## Tests
- `go test -run '^TestAzureOpenAIDeploymentName$' -count=1 -timeout=30s .`\n- `go test -run '^$' -count=1 -timeout=30s .`\n- `git diff --check`\n