### PR TITLE
feat(mcp): add OAuth 2.1 bearer auth for streamable-http server

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,6 +464,8 @@ kubectl-ai --mcp-server --mcp-server-mode streamable-http --http-port 9080 \
   --mcp-auth-audience https://kubectl-ai.corp/mcp
 ```
 
+`--mcp-auth-audience` is this server's resource identifier; the JWT's `aud` claim must match it, which binds each token to *this* MCP server and prevents tokens issued for other services (same authorization server) from being replayed here. It is required once `--mcp-auth-issuer` is set — see [Why the audience (`aud`) matters](docs/mcp-server.md#why-the-audience-aud-matters).
+
 Authentication is opt-in: without `--mcp-auth-issuer` the endpoint behaves exactly as before. See the [MCP Server Documentation](docs/mcp-server.md#securing-the-http-endpoint-with-oauth-21-authgate) for details.
 
 📖 **For detailed configuration, examples, and troubleshooting, see the [MCP Server Documentation](docs/mcp-server.md).**

--- a/README.md
+++ b/README.md
@@ -454,6 +454,18 @@ This starts an MCP endpoint at `http://localhost:9080/mcp`.
 
 The enhanced mode provides AI clients with access to both Kubernetes operations and general-purpose tools (filesystem, web search, databases, etc.) through a single MCP endpoint.
 
+### Authenticating the HTTP Endpoint (OAuth 2.1)
+
+The `streamable-http` endpoint is unauthenticated by default — anyone who can reach the port can run `kubectl` and `bash`. For non-localhost use, turn the server into an OAuth 2.1 Resource Server that requires a Bearer access token (verified locally against an authorization server's JWKS, e.g. [AuthGate](https://github.com/go-authgate/authgate)):
+
+```bash
+kubectl-ai --mcp-server --mcp-server-mode streamable-http --http-port 9080 \
+  --mcp-auth-issuer https://authgate.corp \
+  --mcp-auth-audience https://kubectl-ai.corp/mcp
+```
+
+Authentication is opt-in: without `--mcp-auth-issuer` the endpoint behaves exactly as before. See the [MCP Server Documentation](docs/mcp-server.md#securing-the-http-endpoint-with-oauth-21-authgate) for details.
+
 📖 **For detailed configuration, examples, and troubleshooting, see the [MCP Server Documentation](docs/mcp-server.md).**
 
 ## Start Contributing

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -34,6 +34,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubectl-ai/pkg/agent"
 	"github.com/GoogleCloudPlatform/kubectl-ai/pkg/api"
 	"github.com/GoogleCloudPlatform/kubectl-ai/pkg/journal"
+	"github.com/GoogleCloudPlatform/kubectl-ai/pkg/mcpauth"
 	"github.com/GoogleCloudPlatform/kubectl-ai/pkg/sessions"
 	"github.com/GoogleCloudPlatform/kubectl-ai/pkg/tools"
 	"github.com/GoogleCloudPlatform/kubectl-ai/pkg/ui"
@@ -100,6 +101,18 @@ type Options struct {
 	MCPServerMode string `json:"mcpServerMode,omitempty"`
 	// Set the HTTP endpoint port for the MCP server when using HTTP transports like streamable-http.
 	HTTPPort int `json:"httpPort,omitempty"`
+
+	// MCP server OAuth 2.1 bearer authentication (streamable-http mode only).
+	// MCPAuthIssuer is the Authorization Server base URL (= JWT `iss`).
+	// A non-empty value enables authentication; empty keeps the previous,
+	// unauthenticated behavior.
+	MCPAuthIssuer string `json:"mcpAuthIssuer,omitempty"`
+	// MCPAuthAudience is this MCP server's resource identifier (expected JWT
+	// `aud`). Required when MCPAuthIssuer is set.
+	MCPAuthAudience string `json:"mcpAuthAudience,omitempty"`
+	// MCPAuthJWKSURL optionally overrides the JWKS URL; empty uses issuer-only
+	// OIDC discovery.
+	MCPAuthJWKSURL string `json:"mcpAuthJwksUrl,omitempty"`
 	// KubeConfigPath is the path to the kubeconfig file.
 	// If not provided, the default kubeconfig path will be used.
 	KubeConfigPath string `json:"kubeConfigPath,omitempty"`
@@ -178,6 +191,10 @@ func (o *Options) InitDefaults() {
 	o.MCPServerMode = "stdio"
 	// Default port for HTTP endpoint when using streamable-http mode
 	o.HTTPPort = 9080
+	// MCP server authentication is opt-in and disabled by default
+	o.MCPAuthIssuer = ""
+	o.MCPAuthAudience = ""
+	o.MCPAuthJWKSURL = ""
 
 	// Session management options
 	o.ResumeSession = ""
@@ -321,6 +338,9 @@ func (opt *Options) bindCLIFlags(f *pflag.FlagSet) error {
 	f.BoolVar(&opt.MCPClient, "mcp-client", opt.MCPClient, "enable MCP client mode to connect to external MCP servers")
 	f.StringVar(&opt.MCPServerMode, "mcp-server-mode", opt.MCPServerMode, "mode of the MCP server. Supported values: stdio, streamable-http")
 	f.IntVar(&opt.HTTPPort, "http-port", opt.HTTPPort, "port for the HTTP endpoint in MCP server mode (used with --mcp-server when --mcp-server-mode is streamable-http)")
+	f.StringVar(&opt.MCPAuthIssuer, "mcp-auth-issuer", opt.MCPAuthIssuer, "OAuth 2.1 authorization server base URL (JWT issuer). Non-empty enables Bearer authentication on the MCP server's streamable-http endpoint")
+	f.StringVar(&opt.MCPAuthAudience, "mcp-auth-audience", opt.MCPAuthAudience, "expected JWT audience (this MCP server's resource identifier). Required when --mcp-auth-issuer is set")
+	f.StringVar(&opt.MCPAuthJWKSURL, "mcp-auth-jwks-url", opt.MCPAuthJWKSURL, "optional override for the JWKS URL; empty uses OIDC discovery from the issuer")
 	f.BoolVar(&opt.EnableToolUseShim, "enable-tool-use-shim", opt.EnableToolUseShim, "enable tool use shim")
 	f.BoolVar(&opt.Quiet, "quiet", opt.Quiet, "run in non-interactive mode, requires a query to be provided as a positional argument")
 
@@ -694,7 +714,21 @@ func startMCPServer(ctx context.Context, opt Options) error {
 	if err := os.MkdirAll(workDir, 0o755); err != nil {
 		return fmt.Errorf("error creating work directory: %w", err)
 	}
-	mcpServer, err := newKubectlMCPServer(ctx, opt.KubeConfigPath, tools.Default(), workDir, opt.ExternalTools, opt.MCPServerMode, opt.HTTPPort)
+
+	authConfig := mcpauth.Config{
+		Issuer:   opt.MCPAuthIssuer,
+		Audience: opt.MCPAuthAudience,
+		JWKSURL:  opt.MCPAuthJWKSURL,
+	}
+	if authConfig.Enabled() && opt.MCPServerMode != "streamable-http" {
+		// Authentication only applies to the streamable-http transport, which is
+		// the only mode that exposes a network endpoint. The remaining config
+		// invariants (audience required, valid URLs) are enforced by
+		// mcpauth.NewVerifier so there is a single source of truth.
+		klog.Warningf("--mcp-auth-issuer is set but --mcp-server-mode is %q; authentication only applies to streamable-http and will be ignored", opt.MCPServerMode)
+	}
+
+	mcpServer, err := newKubectlMCPServer(ctx, opt.KubeConfigPath, tools.Default(), workDir, opt.ExternalTools, opt.MCPServerMode, opt.HTTPPort, authConfig)
 	if err != nil {
 		return fmt.Errorf("creating mcp server: %w", err)
 	}

--- a/cmd/mcp.go
+++ b/cmd/mcp.go
@@ -17,9 +17,11 @@ package main
 import (
 	"context"
 	"fmt"
+	"net/http"
 
 	"github.com/GoogleCloudPlatform/kubectl-ai/gollm"
 	"github.com/GoogleCloudPlatform/kubectl-ai/pkg/mcp"
+	"github.com/GoogleCloudPlatform/kubectl-ai/pkg/mcpauth"
 	"github.com/GoogleCloudPlatform/kubectl-ai/pkg/sandbox"
 	"github.com/GoogleCloudPlatform/kubectl-ai/pkg/tools"
 	mcpgo "github.com/mark3labs/mcp-go/mcp"
@@ -32,12 +34,13 @@ type kubectlMCPServer struct {
 	server        *server.MCPServer
 	tools         tools.Tools
 	workDir       string
-	mcpManager    *mcp.Manager // Add MCP manager for external tool calls
-	mcpServerMode string       // Server mode (e.g., "streamable-http", "stdio")
-	httpPort      int          // Port for HTTP-based server modes
+	mcpManager    *mcp.Manager   // Add MCP manager for external tool calls
+	mcpServerMode string         // Server mode (e.g., "streamable-http", "stdio")
+	httpPort      int            // Port for HTTP-based server modes
+	authConfig    mcpauth.Config // OAuth 2.1 bearer auth (only used in streamable-http mode; disabled when Issuer is empty)
 }
 
-func newKubectlMCPServer(ctx context.Context, kubectlConfig string, t tools.Tools, workDir string, exposeExternalTools bool, serverMode string, httpPort int) (*kubectlMCPServer, error) {
+func newKubectlMCPServer(ctx context.Context, kubectlConfig string, t tools.Tools, workDir string, exposeExternalTools bool, serverMode string, httpPort int, authConfig mcpauth.Config) (*kubectlMCPServer, error) {
 	// Register built-in tools (bash and kubectl) which require an executor.
 	// In MCP server mode, we use a local executor since there's no sandbox.
 	executor := sandbox.NewLocalExecutor()
@@ -55,6 +58,7 @@ func newKubectlMCPServer(ctx context.Context, kubectlConfig string, t tools.Tool
 		tools:         t,
 		mcpServerMode: serverMode,
 		httpPort:      httpPort,
+		authConfig:    authConfig,
 	}
 
 	// Add built-in tools
@@ -174,10 +178,25 @@ func (s *kubectlMCPServer) Serve(ctx context.Context) error {
 	case "streamable-http":
 		// Start the server in streamable HTTP mode
 		klog.Infof("Starting MCP server in streamable HTTP mode on port %d", s.httpPort)
-		httpServer := server.NewStreamableHTTPServer(s.server)
+		mcpHandler := server.NewStreamableHTTPServer(s.server)
 		endpoint := fmt.Sprintf(":%d", s.httpPort)
+
+		if s.authConfig.Enabled() {
+			// OAuth 2.1 Resource Server: require a valid Bearer access token on
+			// /mcp and publish Protected Resource Metadata for client discovery.
+			verifier, err := mcpauth.NewVerifier(ctx, s.authConfig)
+			if err != nil {
+				return fmt.Errorf("init MCP auth: %w", err)
+			}
+			mux := http.NewServeMux()
+			mux.Handle(mcpauth.PRMPath, s.authConfig.PRMHandler())
+			mux.Handle("/mcp", verifier.Middleware(mcpHandler))
+			klog.Infof("Listening for streamable HTTP connections on port %d (authentication enabled)", s.httpPort)
+			return http.ListenAndServe(endpoint, mux)
+		}
+
 		klog.Infof("Listening for streamable HTTP connections on port %d", s.httpPort)
-		return httpServer.Start(endpoint)
+		return mcpHandler.Start(endpoint)
 	default:
 		return server.ServeStdio(s.server)
 	}

--- a/cmd/mcp_test.go
+++ b/cmd/mcp_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/kubectl-ai/gollm"
 	"github.com/GoogleCloudPlatform/kubectl-ai/pkg/mcp"
+	"github.com/GoogleCloudPlatform/kubectl-ai/pkg/mcpauth"
 	"github.com/GoogleCloudPlatform/kubectl-ai/pkg/tools"
 )
 
@@ -38,7 +39,7 @@ func TestKubectlMCPServerHTTPClientIntegration(t *testing.T) {
 
 	workDir := t.TempDir()
 
-	server, err := newKubectlMCPServer(ctx, "", toolset, workDir, false, "streamable-http", port)
+	server, err := newKubectlMCPServer(ctx, "", toolset, workDir, false, "streamable-http", port, mcpauth.Config{})
 	if err != nil {
 		t.Fatalf("failed to create MCP server: %v", err)
 	}

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -33,6 +33,73 @@ kubectl-ai --mcp-server --mcp-server-mode streamable-http --http-port 9080
 
 This listens on `http://localhost:9080/mcp` by default.
 
+> **Warning:** Without authentication, anyone who can reach this port can execute
+> arbitrary `kubectl` and `bash` commands through the MCP protocol. When exposing
+> the `streamable-http` endpoint beyond localhost, enable authentication (see
+> below).
+
+### Securing the HTTP Endpoint with OAuth 2.1 (AuthGate)
+
+In `streamable-http` mode the MCP server can act as an OAuth 2.1 **Resource
+Server**, requiring callers to present a valid `Authorization: Bearer <JWT>`
+access token. Tokens are verified locally against the Authorization Server's
+JWKS (signature + `iss` + `aud` + `exp`, and `type == access`). This integrates
+with [go-authgate/authgate](https://github.com/go-authgate/authgate) as the
+Authorization Server, but works with any OAuth 2.1 / OIDC server that publishes
+a JWKS.
+
+Authentication is **opt-in**: if `--mcp-auth-issuer` is not set, the endpoint
+behaves exactly as before (no authentication, no metadata endpoint).
+
+```bash
+kubectl-ai --mcp-server --mcp-server-mode streamable-http --http-port 9080 \
+  --mcp-auth-issuer https://authgate.corp \
+  --mcp-auth-audience https://kubectl-ai.corp/mcp
+```
+
+What this enables:
+
+- `POST /mcp` requires a valid Bearer access token. Missing or invalid tokens
+  receive `401 Unauthorized` with a `WWW-Authenticate` header pointing at the
+  Protected Resource Metadata document.
+- `GET /.well-known/oauth-protected-resource` serves the Protected Resource
+  Metadata (RFC 9728) — unauthenticated — so MCP clients can discover the
+  Authorization Server automatically:
+
+  ```json
+  {
+    "resource": "https://kubectl-ai.corp/mcp",
+    "authorization_servers": ["https://authgate.corp"],
+    "bearer_methods_supported": ["header"]
+  }
+  ```
+
+Authentication flags:
+
+| Flag                  | Description                                                                                                                               |
+| --------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `--mcp-auth-issuer`   | Authorization Server base URL (= JWT `iss`). **Non-empty enables authentication.** Empty keeps the previous, unauthenticated behavior.    |
+| `--mcp-auth-audience` | This server's resource identifier (expected JWT `aud`, e.g. `https://kubectl-ai.corp/mcp`). **Required** when `--mcp-auth-issuer` is set. |
+| `--mcp-auth-jwks-url` | Optional override for the JWKS URL. Empty uses OIDC discovery from `<issuer>/.well-known/openid-configuration`.                           |
+
+Behavior notes:
+
+- **Fail-fast on configuration errors:** an invalid issuer URL or a missing
+  audience aborts startup with a clear error.
+- **Tolerant of a temporarily unreachable Authorization Server:** if the JWKS
+  cannot be fetched at startup, kubectl-ai logs a warning and keeps retrying in
+  the background instead of crashing.
+- **Fail-closed while keys are unavailable:** until signing keys are loaded,
+  `/mcp` returns `503 Service Unavailable` rather than letting any request
+  through.
+- **Reverse proxies:** the `resource_metadata` URL in the `WWW-Authenticate`
+  header is built from `X-Forwarded-Proto` (falling back to TLS detection) and
+  the request `Host`. Make sure your proxy forwards `X-Forwarded-Proto`.
+
+> **Tip:** [go-authgate/authgate](https://github.com/go-authgate/authgate) can
+> be used as the Authorization Server that issues and signs these access tokens.
+> See its documentation for installation and client setup.
+
 ## Configuration
 
 When `--external-tools` is enabled, the enhanced MCP server will automatically discover and expose tools from configured MCP servers. You can configure MCP servers using the standard MCP client configuration file.
@@ -128,13 +195,16 @@ Additional tools are available depending on the configured MCP servers:
 
 ## Command Line Options
 
-| Flag                | Default          | Description                                                            |
-| ------------------- | ---------------- | ---------------------------------------------------------------------- |
-| `--mcp-server`      | `false`          | Run in MCP server mode                                                 |
-| `--external-tools`  | `false`          | Discover and expose external MCP tools (requires --mcp-server)         |
-| `--kubeconfig`      | `~/.kube/config` | Path to kubeconfig file                                                |
-| `--mcp-server-mode` | `stdio`          | Transport for the MCP server (`stdio` or `streamable-http`)    |
-| `--http-port`       | `9080`           | Port for the HTTP endpoint when using `streamable-http` modes |
+| Flag                  | Default          | Description                                                                                                           |
+| --------------------- | ---------------- | --------------------------------------------------------------------------------------------------------------------- |
+| `--mcp-server`        | `false`          | Run in MCP server mode                                                                                                |
+| `--external-tools`    | `false`          | Discover and expose external MCP tools (requires --mcp-server)                                                        |
+| `--kubeconfig`        | `~/.kube/config` | Path to kubeconfig file                                                                                               |
+| `--mcp-server-mode`   | `stdio`          | Transport for the MCP server (`stdio` or `streamable-http`)                                                           |
+| `--http-port`         | `9080`           | Port for the HTTP endpoint when using `streamable-http` modes                                                         |
+| `--mcp-auth-issuer`   | `""`             | OAuth 2.1 authorization server base URL (JWT issuer). Non-empty enables Bearer auth on the `streamable-http` endpoint |
+| `--mcp-auth-audience` | `""`             | Expected JWT audience (this server's resource identifier). Required when `--mcp-auth-issuer` is set                   |
+| `--mcp-auth-jwks-url` | `""`             | Optional override for the JWKS URL; empty uses OIDC discovery from the issuer                                         |
 
 ## Architecture
 

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -82,6 +82,40 @@ Authentication flags:
 | `--mcp-auth-audience` | This server's resource identifier (expected JWT `aud`, e.g. `https://kubectl-ai.corp/mcp`). **Required** when `--mcp-auth-issuer` is set. |
 | `--mcp-auth-jwks-url` | Optional override for the JWKS URL. Empty uses OIDC discovery from `<issuer>/.well-known/openid-configuration`.                           |
 
+#### Why the audience (`aud`) matters
+
+The `--mcp-auth-audience` value is this server's **resource identifier**. During
+verification kubectl-ai requires the JWT's `aud` claim to match it exactly (in
+addition to checking the signature, `iss`, and `exp`). This is what binds a token
+to *this specific* MCP server, and it is why the flag is mandatory once
+authentication is enabled — there is no safe default to guess.
+
+The signature and `iss` checks only prove the token is *genuine* (really issued
+by your Authorization Server). The `aud` check proves the token was *meant for
+you*. Without it, **any** valid token signed by the same Authorization Server
+would be accepted, which opens up:
+
+- **Cross-service token reuse / confused deputy:** one Authorization Server
+  typically issues tokens for many resource servers (other internal APIs,
+  dashboards, microservices). A user holding a legitimate token for, say, a
+  reporting API could replay it against the MCP server and gain the ability to
+  run `kubectl` and `bash`. With `aud` enforced, that token's audience does not
+  match this server's resource identifier, so it is rejected.
+- **Token theft by a downstream service:** if a token is not bound to an
+  audience, any service that receives it (or a compromised/man-in-the-middle
+  hop) can turn around and impersonate the user against the MCP server. Binding
+  the audience makes a token issued for someone else useless here.
+
+The audience also closes the discovery loop: the value is published verbatim as
+the `resource` field of the Protected Resource Metadata document (see below), so
+compliant MCP clients request a token scoped to exactly this resource (per RFC
+8707 Resource Indicators) and the server then enforces that same scope.
+
+> **Pick a stable, unique value.** Use a URI that uniquely identifies this MCP
+> server (commonly its public `/mcp` URL, e.g. `https://kubectl-ai.corp/mcp`).
+> It must be the same string the Authorization Server stamps into the `aud`
+> claim — a mismatch results in every request being rejected with `401`.
+
 Behavior notes:
 
 - **Fail-fast on configuration errors:** an invalid issuer URL or a missing

--- a/go.mod
+++ b/go.mod
@@ -9,11 +9,13 @@ replace github.com/GoogleCloudPlatform/kubectl-ai/gollm => ./gollm
 
 require (
 	github.com/GoogleCloudPlatform/kubectl-ai/gollm v0.0.0-00010101000000-000000000000
+	github.com/MicahParks/keyfunc/v3 v3.8.0
 	github.com/charmbracelet/bubbles v0.21.0
 	github.com/charmbracelet/bubbletea v1.3.5
 	github.com/charmbracelet/glamour v0.10.0
 	github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834
 	github.com/chzyer/readline v1.5.1
+	github.com/golang-jwt/jwt/v5 v5.2.2
 	github.com/google/uuid v1.6.0
 	github.com/mark3labs/mcp-go v0.41.1
 	github.com/spf13/cobra v1.9.1
@@ -40,6 +42,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cognitiveservices/armcognitiveservices v1.7.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/subscription/armsubscription v1.2.0 // indirect
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.4.2 // indirect
+	github.com/MicahParks/jwkset v0.11.0 // indirect
 	github.com/alecthomas/chroma/v2 v2.14.0 // indirect
 	github.com/anthropics/anthropic-sdk-go v1.26.0 // indirect
 	github.com/atotto/clipboard v0.1.4 // indirect
@@ -79,7 +82,6 @@ require (
 	github.com/go-openapi/jsonreference v0.20.2 // indirect
 	github.com/go-openapi/swag v0.23.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
-	github.com/golang-jwt/jwt/v5 v5.2.2 // indirect
 	github.com/google/gnostic-models v0.7.0 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -22,6 +22,10 @@ github.com/AzureAD/microsoft-authentication-extensions-for-go/cache v0.1.1 h1:WJ
 github.com/AzureAD/microsoft-authentication-extensions-for-go/cache v0.1.1/go.mod h1:tCcJZ0uHAmvjsVYzEFivsRTN00oz5BEsRgQHu5JZ9WE=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.4.2 h1:oygO0locgZJe7PpYPXT5A29ZkwJaPqcva7BVeemZOZs=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.4.2/go.mod h1:wP83P5OoQ5p6ip3ScPr0BAq0BvuPAvacpEuSzyouqAI=
+github.com/MicahParks/jwkset v0.11.0 h1:yc0zG+jCvZpWgFDFmvs8/8jqqVBG9oyIbmBtmjOhoyQ=
+github.com/MicahParks/jwkset v0.11.0/go.mod h1:U2oRhRaLgDCLjtpGL2GseNKGmZtLs/3O7p+OZaL5vo0=
+github.com/MicahParks/keyfunc/v3 v3.8.0 h1:Hx2dgIjAXGk9slakM6rV9BOeaWDPEXXZ4Us8guNBfds=
+github.com/MicahParks/keyfunc/v3 v3.8.0/go.mod h1:z66bkCviwqfg2YUp+Jcc/xRE9IXLcMq6DrgV/+Htru0=
 github.com/alecthomas/assert/v2 v2.7.0 h1:QtqSACNS3tF7oasA8CU6A6sXZSBDqnm7RfpLl9bZqbE=
 github.com/alecthomas/assert/v2 v2.7.0/go.mod h1:Bze95FyfUr7x34QZrjL+XP+0qgp/zg8yS+TtBj1WA3k=
 github.com/alecthomas/chroma/v2 v2.14.0 h1:R3+wzpnUArGcQz7fCETQBzO5n9IMNi13iIs46aU4V9E=

--- a/pkg/mcpauth/auth.go
+++ b/pkg/mcpauth/auth.go
@@ -105,6 +105,10 @@ func isAbsoluteURL(s string) bool {
 //     request (fail-closed) and never lets unverified traffic through.
 type Verifier struct {
 	cfg Config
+	// parser holds the immutable claim-validation rules (iss/aud/exp/alg/leeway).
+	// It is built once in NewVerifier and reused for every request so the option
+	// closures are not re-allocated on the hot path.
+	parser *jwt.Parser
 
 	mu sync.RWMutex
 	kf keyfunc.Keyfunc // nil until signing keys are loaded
@@ -120,7 +124,16 @@ func NewVerifier(ctx context.Context, cfg Config) (*Verifier, error) {
 		return nil, err
 	}
 
-	v := &Verifier{cfg: cfg}
+	v := &Verifier{
+		cfg: cfg,
+		parser: jwt.NewParser(
+			jwt.WithIssuer(cfg.Issuer),
+			jwt.WithAudience(cfg.Audience),
+			jwt.WithExpirationRequired(),
+			jwt.WithValidMethods([]string{"RS256", "ES256"}),
+			jwt.WithLeeway(clockLeeway),
+		),
+	}
 
 	kf, err := v.buildKeyfunc(ctx)
 	if err != nil {
@@ -221,13 +234,7 @@ func (v *Verifier) Middleware(next http.Handler) http.Handler {
 			return
 		}
 
-		token, err := jwt.Parse(tokenStr, kf.Keyfunc,
-			jwt.WithIssuer(v.cfg.Issuer),
-			jwt.WithAudience(v.cfg.Audience),
-			jwt.WithExpirationRequired(),
-			jwt.WithValidMethods([]string{"RS256", "ES256"}),
-			jwt.WithLeeway(clockLeeway),
-		)
+		token, err := v.parser.Parse(tokenStr, kf.Keyfunc)
 		if err != nil || !token.Valid {
 			v.reject(w, r, fmt.Sprintf("token validation failed: %v", err))
 			return

--- a/pkg/mcpauth/auth.go
+++ b/pkg/mcpauth/auth.go
@@ -1,0 +1,338 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package mcpauth turns the kubectl-ai MCP server (streamable-http transport)
+// into an OAuth 2.1 Resource Server. It verifies incoming Bearer access tokens
+// locally against an Authorization Server's JWKS and publishes a Protected
+// Resource Metadata document (RFC 9728) so MCP clients can discover the AS.
+//
+// Authentication is purely opt-in: a zero-value Config (empty issuer) reports
+// Enabled() == false and the caller keeps its previous, unauthenticated
+// behavior.
+package mcpauth
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/MicahParks/keyfunc/v3"
+	"github.com/golang-jwt/jwt/v5"
+	"k8s.io/klog/v2"
+)
+
+// PRMPath is the well-known path for the Protected Resource Metadata document
+// (RFC 9728). It is served without authentication.
+const PRMPath = "/.well-known/oauth-protected-resource"
+
+// clockLeeway tolerates small clock skew between the Authorization Server and
+// this Resource Server when validating time-based claims (exp/nbf/iat).
+const clockLeeway = 30 * time.Second
+
+// httpTimeout bounds each JWKS / discovery HTTP request so a slow or
+// black-holed Authorization Server cannot block kubectl-ai startup.
+const httpTimeout = 10 * time.Second
+
+// retryInterval is how often we re-attempt to load signing keys after an
+// initial failure to reach the Authorization Server.
+const retryInterval = 30 * time.Second
+
+// Config describes how the MCP server authenticates incoming requests.
+type Config struct {
+	// Issuer is the AuthGate base URL, expected as the JWT `iss` claim.
+	// An empty Issuer disables authentication entirely.
+	Issuer string
+	// Audience is this Resource Server's identifier, expected as the JWT `aud`
+	// claim (for example "https://kubectl-ai.corp/mcp").
+	Audience string
+	// JWKSURL optionally overrides the JWKS URL. When empty it is discovered
+	// from <Issuer>/.well-known/openid-configuration.
+	JWKSURL string
+}
+
+// Enabled reports whether authentication is configured. When false the caller
+// should keep its previous, unauthenticated behavior.
+func (c Config) Enabled() bool { return c.Issuer != "" }
+
+// validate checks configuration that can be verified without any network
+// access, so obvious mistakes (typos) fail fast at startup.
+func (c Config) validate() error {
+	if c.Issuer == "" {
+		return fmt.Errorf("issuer must not be empty when authentication is enabled")
+	}
+	if !isAbsoluteURL(c.Issuer) {
+		return fmt.Errorf("issuer %q is not a valid absolute URL", c.Issuer)
+	}
+	if c.Audience == "" {
+		return fmt.Errorf("audience is required when issuer is set")
+	}
+	if c.JWKSURL != "" && !isAbsoluteURL(c.JWKSURL) {
+		return fmt.Errorf("jwks-url %q is not a valid absolute URL", c.JWKSURL)
+	}
+	return nil
+}
+
+// isAbsoluteURL reports whether s parses as an absolute URL with a host.
+func isAbsoluteURL(s string) bool {
+	u, err := url.Parse(s)
+	return err == nil && u.IsAbs() && u.Host != ""
+}
+
+// Verifier validates Bearer tokens against the Authorization Server's JWKS.
+//
+// Startup strategy (never fail-open):
+//   - Configuration errors that need no network (bad issuer URL, missing
+//     audience) fail fast in NewVerifier.
+//   - A temporarily unreachable Authorization Server does NOT crash the
+//     process: NewVerifier logs a warning and keeps retrying in the background.
+//   - While signing keys are not yet loaded, Middleware returns 503 for every
+//     request (fail-closed) and never lets unverified traffic through.
+type Verifier struct {
+	cfg Config
+
+	mu sync.RWMutex
+	kf keyfunc.Keyfunc // nil until signing keys are loaded
+}
+
+// NewVerifier validates the config, then attempts to load signing keys.
+//
+// It returns an error only for configuration problems (fail-fast). If the
+// Authorization Server is merely unreachable, it returns a usable Verifier that
+// reports "not ready" (Middleware -> 503) and loads keys in the background.
+func NewVerifier(ctx context.Context, cfg Config) (*Verifier, error) {
+	if err := cfg.validate(); err != nil {
+		return nil, err
+	}
+
+	v := &Verifier{cfg: cfg}
+
+	kf, err := v.buildKeyfunc(ctx)
+	if err != nil {
+		klog.Warningf("MCP auth: could not load signing keys from authorization server %q (%v); "+
+			"starting anyway. /mcp will return 503 until keys are retrieved in the background.", cfg.Issuer, err)
+		go v.retryLoad(ctx)
+		return v, nil
+	}
+
+	v.setKeyfunc(kf)
+	klog.V(1).Infof("MCP auth enabled: issuer=%q audience=%q jwks_url=%q", cfg.Issuer, cfg.Audience, cfg.JWKSURL)
+	return v, nil
+}
+
+// buildKeyfunc resolves the JWKS URL (via discovery unless overridden) and
+// builds a keyfunc. NoErrorReturnFirstHTTPReq is set to false so that a network
+// failure surfaces here (and we retry) instead of silently producing a keyfunc
+// with no keys.
+func (v *Verifier) buildKeyfunc(ctx context.Context) (keyfunc.Keyfunc, error) {
+	jwksURL := v.cfg.JWKSURL
+	if jwksURL == "" {
+		discovered, err := discoverJWKSURL(ctx, v.cfg.Issuer)
+		if err != nil {
+			return nil, err
+		}
+		jwksURL = discovered
+	}
+
+	failOnFirstError := false
+	kf, err := keyfunc.NewDefaultOverrideCtx(ctx, []string{jwksURL}, keyfunc.Override{
+		NoErrorReturnFirstHTTPReq: &failOnFirstError,
+		HTTPTimeout:               httpTimeout,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("loading JWKS from %q: %w", jwksURL, err)
+	}
+	return kf, nil
+}
+
+// retryLoad keeps trying to load signing keys until it succeeds or ctx is done.
+// Key rotation after the first success is handled automatically by keyfunc.
+func (v *Verifier) retryLoad(ctx context.Context) {
+	ticker := time.NewTicker(retryInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+		kf, err := v.buildKeyfunc(ctx)
+		if err != nil {
+			klog.Warningf("MCP auth: still unable to load signing keys from %q: %v", v.cfg.Issuer, err)
+			continue
+		}
+		v.setKeyfunc(kf)
+		klog.Infof("MCP auth: loaded signing keys from %q; /mcp authentication is now active", v.cfg.Issuer)
+		return
+	}
+}
+
+func (v *Verifier) setKeyfunc(kf keyfunc.Keyfunc) {
+	v.mu.Lock()
+	v.kf = kf
+	v.mu.Unlock()
+}
+
+func (v *Verifier) keyfunc() (keyfunc.Keyfunc, bool) {
+	v.mu.RLock()
+	defer v.mu.RUnlock()
+	return v.kf, v.kf != nil
+}
+
+// Middleware wraps next so that only requests carrying a valid access token are
+// passed through. Requests are rejected with 503 while keys are not yet loaded
+// and 401 when the token is missing or invalid.
+func (v *Verifier) Middleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		kf, ready := v.keyfunc()
+		if !ready {
+			// Fail-closed: keys not yet available, do not attempt to verify and
+			// do not let the request through.
+			klog.V(2).Info("MCP auth: signing keys not ready, returning 503")
+			w.Header().Set("Retry-After", "5")
+			http.Error(w, "authorization server signing keys are not yet available", http.StatusServiceUnavailable)
+			return
+		}
+
+		const bearerPrefix = "Bearer "
+		authz := r.Header.Get("Authorization")
+		if len(authz) < len(bearerPrefix) || !strings.EqualFold(authz[:len(bearerPrefix)], bearerPrefix) {
+			v.reject(w, r, "missing or malformed Authorization header")
+			return
+		}
+		tokenStr := strings.TrimSpace(authz[len(bearerPrefix):])
+		if tokenStr == "" {
+			v.reject(w, r, "empty bearer token")
+			return
+		}
+
+		token, err := jwt.Parse(tokenStr, kf.Keyfunc,
+			jwt.WithIssuer(v.cfg.Issuer),
+			jwt.WithAudience(v.cfg.Audience),
+			jwt.WithExpirationRequired(),
+			jwt.WithValidMethods([]string{"RS256", "ES256"}),
+			jwt.WithLeeway(clockLeeway),
+		)
+		if err != nil || !token.Valid {
+			v.reject(w, r, fmt.Sprintf("token validation failed: %v", err))
+			return
+		}
+
+		claims, ok := token.Claims.(jwt.MapClaims)
+		if !ok {
+			v.reject(w, r, "unexpected claims type")
+			return
+		}
+		// The `type` claim check is security-critical: refresh tokens are signed
+		// with the same key as access tokens, so without this check a refresh
+		// token could be presented in place of an access token.
+		if t, _ := claims["type"].(string); t != "access" {
+			v.reject(w, r, "token type is not \"access\"")
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}
+
+// reject writes a 401 with a WWW-Authenticate header pointing MCP clients at
+// the Protected Resource Metadata document.
+func (v *Verifier) reject(w http.ResponseWriter, r *http.Request, reason string) {
+	klog.V(2).Infof("MCP auth: rejecting request: %s", reason)
+	w.Header().Set("WWW-Authenticate", wwwAuthenticate(r))
+	http.Error(w, "invalid token", http.StatusUnauthorized)
+}
+
+// wwwAuthenticate builds the RFC 9728 WWW-Authenticate challenge advertising the
+// Protected Resource Metadata URL. The scheme prefers X-Forwarded-Proto so the
+// URL is correct behind a reverse proxy.
+func wwwAuthenticate(r *http.Request) string {
+	scheme := "http"
+	if r.TLS != nil {
+		scheme = "https"
+	}
+	if proto := r.Header.Get("X-Forwarded-Proto"); proto != "" {
+		scheme = proto
+	}
+	prm := fmt.Sprintf("%s://%s%s", scheme, r.Host, PRMPath)
+	return fmt.Sprintf("Bearer resource_metadata=%q, error=%q", prm, "invalid_token")
+}
+
+// PRMHandler serves the Protected Resource Metadata document (RFC 9728). It
+// requires no authentication and carries permissive CORS headers so that
+// browser-based MCP clients can fetch it cross-origin.
+func (c Config) PRMHandler() http.HandlerFunc {
+	body, _ := json.Marshal(map[string]any{
+		"resource":                 c.Audience,
+		"authorization_servers":    []string{c.Issuer},
+		"bearer_methods_supported": []string{"header"},
+	})
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Header().Set("Access-Control-Allow-Methods", "GET, OPTIONS")
+		w.Header().Set("Access-Control-Allow-Headers", "Authorization, Content-Type")
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(body)
+	}
+}
+
+// discoverJWKSURL fetches <issuer>/.well-known/openid-configuration and returns
+// its jwks_uri. The request is bounded by httpTimeout so it cannot block
+// startup indefinitely.
+func discoverJWKSURL(ctx context.Context, issuer string) (string, error) {
+	ctx, cancel := context.WithTimeout(ctx, httpTimeout)
+	defer cancel()
+
+	metaURL := strings.TrimRight(issuer, "/") + "/.well-known/openid-configuration"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, metaURL, nil)
+	if err != nil {
+		return "", fmt.Errorf("building discovery request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("fetching %q: %w", metaURL, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("discovery %q returned status %d", metaURL, resp.StatusCode)
+	}
+
+	var doc struct {
+		Issuer  string `json:"issuer"`
+		JWKSURI string `json:"jwks_uri"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&doc); err != nil {
+		return "", fmt.Errorf("decoding discovery document from %q: %w", metaURL, err)
+	}
+	if doc.JWKSURI == "" {
+		return "", fmt.Errorf("discovery document %q has no jwks_uri", metaURL)
+	}
+	if doc.Issuer != "" && doc.Issuer != issuer {
+		klog.Warningf("MCP auth: discovery issuer %q does not match configured issuer %q", doc.Issuer, issuer)
+	}
+	klog.V(1).Infof("MCP auth: discovered jwks_uri %q from %q", doc.JWKSURI, metaURL)
+	return doc.JWKSURI, nil
+}

--- a/pkg/mcpauth/auth_test.go
+++ b/pkg/mcpauth/auth_test.go
@@ -1,0 +1,354 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mcpauth
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/json"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+const testKID = "test-key-1"
+
+// fixture bundles a self-signed RSA key, an httptest server that serves the
+// matching JWKS (and an OIDC discovery document), and the resulting auth Config.
+type fixture struct {
+	key      *rsa.PrivateKey
+	server   *httptest.Server
+	issuer   string
+	audience string
+	jwksURL  string
+}
+
+func newFixture(t *testing.T) *fixture {
+	t.Helper()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generating RSA key: %v", err)
+	}
+
+	f := &fixture{key: key, audience: "https://kubectl-ai.test/mcp"}
+
+	jwksBytes := jwksJSON(t, testKID, &key.PublicKey)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/jwks", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(jwksBytes)
+	})
+	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"issuer":   f.issuer,
+			"jwks_uri": f.jwksURL,
+		})
+	})
+
+	f.server = httptest.NewServer(mux)
+	t.Cleanup(f.server.Close)
+	f.issuer = f.server.URL
+	f.jwksURL = f.server.URL + "/jwks"
+	return f
+}
+
+// jwksJSON builds a minimal JWKS document containing the RSA public key.
+func jwksJSON(t *testing.T, kid string, pub *rsa.PublicKey) []byte {
+	t.Helper()
+	n := base64.RawURLEncoding.EncodeToString(pub.N.Bytes())
+	e := base64.RawURLEncoding.EncodeToString(big.NewInt(int64(pub.E)).Bytes())
+	set := map[string]any{
+		"keys": []map[string]any{
+			{"kty": "RSA", "use": "sig", "alg": "RS256", "kid": kid, "n": n, "e": e},
+		},
+	}
+	b, err := json.Marshal(set)
+	if err != nil {
+		t.Fatalf("marshaling JWKS: %v", err)
+	}
+	return b
+}
+
+func (f *fixture) validClaims() jwt.MapClaims {
+	return jwt.MapClaims{
+		"iss":  f.issuer,
+		"aud":  f.audience,
+		"type": "access",
+		"iat":  jwt.NewNumericDate(time.Now()),
+		"exp":  jwt.NewNumericDate(time.Now().Add(time.Hour)),
+	}
+}
+
+func (f *fixture) sign(t *testing.T, claims jwt.MapClaims) string {
+	t.Helper()
+	tok := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	tok.Header["kid"] = testKID
+	signed, err := tok.SignedString(f.key)
+	if err != nil {
+		t.Fatalf("signing token: %v", err)
+	}
+	return signed
+}
+
+// readyVerifier returns a Verifier with signing keys loaded, using the JWKS URL
+// override so no discovery round trip is needed.
+func (f *fixture) readyVerifier(t *testing.T) *Verifier {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	v, err := NewVerifier(ctx, Config{Issuer: f.issuer, Audience: f.audience, JWKSURL: f.jwksURL})
+	if err != nil {
+		t.Fatalf("NewVerifier: %v", err)
+	}
+	if _, ready := v.keyfunc(); !ready {
+		t.Fatalf("verifier is not ready after NewVerifier with reachable JWKS")
+	}
+	return v
+}
+
+// runMiddleware sends req through v.Middleware and reports the response plus
+// whether the wrapped (protected) handler was reached.
+func runMiddleware(v *Verifier, req *http.Request) (*httptest.ResponseRecorder, bool) {
+	nextCalled := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		nextCalled = true
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("tool-output"))
+	})
+	rec := httptest.NewRecorder()
+	v.Middleware(next).ServeHTTP(rec, req)
+	return rec, nextCalled
+}
+
+func bearer(token string) *http.Request {
+	req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	return req
+}
+
+// Test 1: a well-formed access token is accepted and the request is forwarded.
+func TestMiddleware_HappyPath(t *testing.T) {
+	f := newFixture(t)
+	v := f.readyVerifier(t)
+
+	rec, nextCalled := runMiddleware(v, bearer(f.sign(t, f.validClaims())))
+
+	if !nextCalled {
+		t.Errorf("expected protected handler to be called")
+	}
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d", rec.Code)
+	}
+}
+
+// Test 2: missing or malformed credentials yield 401 with a WWW-Authenticate
+// header that points clients at the Protected Resource Metadata document.
+func TestMiddleware_MissingOrMalformedToken(t *testing.T) {
+	f := newFixture(t)
+	v := f.readyVerifier(t)
+
+	cases := map[string]*http.Request{
+		"no header":   httptest.NewRequest(http.MethodPost, "/mcp", nil),
+		"not bearer":  withHeader(httptest.NewRequest(http.MethodPost, "/mcp", nil), "Authorization", "Basic abc123"),
+		"empty token": bearer(""),
+	}
+
+	for name, req := range cases {
+		t.Run(name, func(t *testing.T) {
+			rec, nextCalled := runMiddleware(v, req)
+			if nextCalled {
+				t.Errorf("protected handler must not be called")
+			}
+			if rec.Code != http.StatusUnauthorized {
+				t.Errorf("expected status 401, got %d", rec.Code)
+			}
+			wwwAuth := rec.Header().Get("WWW-Authenticate")
+			if !strings.Contains(wwwAuth, "resource_metadata=") || !strings.Contains(wwwAuth, PRMPath) {
+				t.Errorf("WWW-Authenticate %q must reference resource_metadata at %q", wwwAuth, PRMPath)
+			}
+		})
+	}
+}
+
+// Test 3 (security-critical): a refresh token, otherwise valid and signed with
+// the same key, must be rejected because its `type` is not "access".
+func TestMiddleware_RefreshTokenRejected(t *testing.T) {
+	f := newFixture(t)
+	v := f.readyVerifier(t)
+
+	claims := f.validClaims()
+	claims["type"] = "refresh"
+
+	rec, nextCalled := runMiddleware(v, bearer(f.sign(t, claims)))
+
+	if nextCalled {
+		t.Errorf("protected handler must not be called for a refresh token")
+	}
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("expected status 401, got %d", rec.Code)
+	}
+	if !strings.Contains(rec.Header().Get("WWW-Authenticate"), "invalid_token") {
+		t.Errorf("expected error=invalid_token in WWW-Authenticate, got %q", rec.Header().Get("WWW-Authenticate"))
+	}
+}
+
+// Test 4: a token addressed to a different audience must be rejected.
+func TestMiddleware_WrongAudience(t *testing.T) {
+	f := newFixture(t)
+	v := f.readyVerifier(t)
+
+	claims := f.validClaims()
+	claims["aud"] = "https://someone-else.test/mcp"
+
+	rec, nextCalled := runMiddleware(v, bearer(f.sign(t, claims)))
+
+	if nextCalled {
+		t.Errorf("protected handler must not be called for a wrong-audience token")
+	}
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("expected status 401, got %d", rec.Code)
+	}
+}
+
+// Test 5: an expired token must be rejected.
+func TestMiddleware_ExpiredToken(t *testing.T) {
+	f := newFixture(t)
+	v := f.readyVerifier(t)
+
+	claims := f.validClaims()
+	claims["iat"] = jwt.NewNumericDate(time.Now().Add(-2 * time.Hour))
+	claims["exp"] = jwt.NewNumericDate(time.Now().Add(-1 * time.Hour))
+
+	rec, nextCalled := runMiddleware(v, bearer(f.sign(t, claims)))
+
+	if nextCalled {
+		t.Errorf("protected handler must not be called for an expired token")
+	}
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("expected status 401, got %d", rec.Code)
+	}
+}
+
+// Test 6: the PRM endpoint is unauthenticated, returns the expected JSON, and
+// carries permissive CORS headers.
+func TestPRMHandler(t *testing.T) {
+	f := newFixture(t)
+	cfg := Config{Issuer: f.issuer, Audience: f.audience}
+
+	rec := httptest.NewRecorder()
+	cfg.PRMHandler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, PRMPath, nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rec.Code)
+	}
+	if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "*" {
+		t.Errorf("expected CORS allow-origin '*', got %q", got)
+	}
+
+	var doc struct {
+		Resource             string   `json:"resource"`
+		AuthorizationServers []string `json:"authorization_servers"`
+		BearerMethods        []string `json:"bearer_methods_supported"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &doc); err != nil {
+		t.Fatalf("unmarshaling PRM body: %v", err)
+	}
+	if doc.Resource != f.audience {
+		t.Errorf("expected resource %q, got %q", f.audience, doc.Resource)
+	}
+	if len(doc.AuthorizationServers) != 1 || doc.AuthorizationServers[0] != f.issuer {
+		t.Errorf("expected authorization_servers [%q], got %v", f.issuer, doc.AuthorizationServers)
+	}
+}
+
+// Test 7 (fail-closed): while signing keys are not yet loaded, a request with an
+// otherwise valid token must get 503 and must never reach the protected handler.
+func TestMiddleware_KeysNotReady(t *testing.T) {
+	f := newFixture(t)
+	// Construct a verifier directly with no keyfunc loaded (keys not ready).
+	v := &Verifier{cfg: Config{Issuer: f.issuer, Audience: f.audience}}
+
+	rec, nextCalled := runMiddleware(v, bearer(f.sign(t, f.validClaims())))
+
+	if nextCalled {
+		t.Errorf("protected handler must not be called while keys are not ready")
+	}
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Errorf("expected status 503, got %d", rec.Code)
+	}
+}
+
+// Test 8 (fail-fast): configuration errors that need no network must cause
+// NewVerifier to return an error.
+func TestNewVerifier_ConfigErrors(t *testing.T) {
+	cases := map[string]Config{
+		"issuer not absolute URL": {Issuer: "not-a-url", Audience: "https://rs.test/mcp"},
+		"missing audience":        {Issuer: "https://issuer.test", Audience: ""},
+		"bad jwks url":            {Issuer: "https://issuer.test", Audience: "https://rs.test/mcp", JWKSURL: "nope"},
+	}
+	for name, cfg := range cases {
+		t.Run(name, func(t *testing.T) {
+			if _, err := NewVerifier(context.Background(), cfg); err == nil {
+				t.Errorf("expected NewVerifier to return an error for %+v", cfg)
+			}
+		})
+	}
+}
+
+// Test 9 (compatibility): a zero-value Config disables authentication.
+func TestConfig_Enabled(t *testing.T) {
+	if (Config{}).Enabled() {
+		t.Errorf("empty Config should report Enabled() == false")
+	}
+	if !(Config{Issuer: "https://issuer.test"}).Enabled() {
+		t.Errorf("Config with issuer should report Enabled() == true")
+	}
+}
+
+// Discovery: NewVerifier with issuer only must resolve the JWKS URL from the
+// OIDC discovery document and become ready.
+func TestNewVerifier_Discovery(t *testing.T) {
+	f := newFixture(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	v, err := NewVerifier(ctx, Config{Issuer: f.issuer, Audience: f.audience})
+	if err != nil {
+		t.Fatalf("NewVerifier with discovery: %v", err)
+	}
+	if _, ready := v.keyfunc(); !ready {
+		t.Fatalf("verifier should be ready after successful discovery")
+	}
+
+	rec, nextCalled := runMiddleware(v, bearer(f.sign(t, f.validClaims())))
+	if !nextCalled || rec.Code != http.StatusOK {
+		t.Errorf("expected discovery-configured verifier to accept a valid token, got status %d (nextCalled=%v)", rec.Code, nextCalled)
+	}
+}
+
+func withHeader(req *http.Request, key, value string) *http.Request {
+	req.Header.Set(key, value)
+	return req
+}


### PR DESCRIPTION
- Add mcpauth package that verifies Bearer access tokens against an authorization server's JWKS via OIDC discovery
- Serve OAuth 2.1 Protected Resource Metadata for client discovery and guard the /mcp endpoint with token-verifying middleware
- Add --mcp-auth-issuer, --mcp-auth-audience, and --mcp-auth-jwks-url flags; authentication is opt-in and only applies to streamable-http
- Require an audience when an issuer is set and warn when auth flags are used with a non-network transport
- Keep the endpoint unauthenticated when no issuer is configured to preserve previous behavior
- Document securing the HTTP endpoint in the README and MCP server docs, noting AuthGate as a usable authorization server