### PR TITLE
fix(tools): treat kubectl --dry-run=none/false as executing so write …

### DIFF
--- a/pkg/tools/kubectl_filter.go
+++ b/pkg/tools/kubectl_filter.go
@@ -196,11 +196,40 @@ func analyzeCall(call *syntax.CallExpr) string {
 	return "unknown"
 }
 
+// dryRunPrevents reports whether a --dry-run value actually prevents the command
+// from mutating cluster state. Only "client"/"server" (and the legacy boolean
+// "true") are non-executing. Crucially, "none" and "false" mean the command runs
+// FOR REAL, so they must NOT be treated as a dry run — otherwise a write op such as
+// `kubectl delete pod x --dry-run=none` would be reclassified read-only and skip the
+// approval gate. An empty or unrecognized value is treated as executing (fail-safe:
+// require approval).
+func dryRunPrevents(value string) bool {
+	switch value {
+	case "client", "server", "true":
+		return true
+	default: // "none", "false", "", or anything unknown -> real execution
+		return false
+	}
+}
+
 // parseKubectlArgs extracts verb, subverb, and dry-run flag from kubectl arguments
 func parseKubectlArgs(args []string) (verb, subVerb string, hasDryRun bool) {
-	for _, arg := range args {
+	for i, arg := range args {
 		if strings.HasPrefix(arg, "--dry-run") {
-			hasDryRun = true
+			if eq := strings.IndexByte(arg, '='); eq >= 0 {
+				// "--dry-run=<value>" form.
+				hasDryRun = dryRunPrevents(arg[eq+1:])
+			} else if arg == "--dry-run" {
+				// Bare "--dry-run", or spaced "--dry-run <value>" form. Only consume the
+				// next token as the value when it is a recognized dry-run keyword;
+				// otherwise the flag is valueless (kubectl's legacy client dry run).
+				switch {
+				case i+1 < len(args) && isDryRunValue(args[i+1]):
+					hasDryRun = dryRunPrevents(args[i+1])
+				default:
+					hasDryRun = true
+				}
+			}
 		}
 		if !strings.HasPrefix(arg, "-") {
 			if verb == "" {
@@ -211,4 +240,14 @@ func parseKubectlArgs(args []string) (verb, subVerb string, hasDryRun bool) {
 		}
 	}
 	return verb, subVerb, hasDryRun
+}
+
+// isDryRunValue reports whether tok is a value that can follow a spaced "--dry-run".
+func isDryRunValue(tok string) bool {
+	switch tok {
+	case "none", "false", "client", "server", "true":
+		return true
+	default:
+		return false
+	}
 }

--- a/pkg/tools/kubectl_filter_test.go
+++ b/pkg/tools/kubectl_filter_test.go
@@ -82,6 +82,13 @@ func TestKubectlModifiesResource(t *testing.T) {
 			{"Dry run apply", "kubectl apply -f deployment.yaml --dry-run", "no"},
 			{"Apply with server dry-run", "kubectl apply -f pod.yaml --dry-run=server", "no"},
 			{"Delete with dry-run", "kubectl delete pod nginx --dry-run client", "no"},
+			// --dry-run=none / --dry-run=false mean the command executes FOR REAL and
+			// must stay classified as a write op (not bypass the approval gate).
+			{"Delete with dry-run=none executes", "kubectl delete pod nginx --dry-run=none", "yes"},
+			{"Delete with dry-run=false executes", "kubectl delete pod nginx --dry-run=false", "yes"},
+			{"Apply with dry-run=none executes", "kubectl apply -f deployment.yaml --dry-run=none", "yes"},
+			{"Delete with spaced dry-run none executes", "kubectl delete pod nginx --dry-run none", "yes"},
+			{"Delete with empty dry-run value executes", "kubectl delete pod nginx --dry-run=", "yes"},
 		},
 		"edge cases": {
 			{"Command with pipe", "kubectl get pods | grep nginx", "unknown"},
@@ -172,6 +179,11 @@ func TestKubectlAnalyzerComponents(t *testing.T) {
 			{"kubectl get pods --dry", "get", "pods", false}, // Not a valid dry-run flag
 			{"echo --dry-run", "", "", true},                 // The current implementation doesn't check if it's kubectl
 			{"kubectl rollout status deployment nginx", "rollout", "status", false},
+			// Executing dry-run values must NOT set hasDryRun (they run for real).
+			{"kubectl delete pod nginx --dry-run=none", "delete", "pod", false},
+			{"kubectl delete pod nginx --dry-run=false", "delete", "pod", false},
+			{"kubectl delete pod nginx --dry-run none", "delete", "pod", false},
+			{"kubectl delete pod nginx --dry-run=", "delete", "pod", false},
 		}
 
 		for _, tt := range tests {


### PR DESCRIPTION
## What

`parseKubectlArgs` (`pkg/tools/kubectl_filter.go`) treated **any** arg starting with `--dry-run` as a dry run. But `kubectl`'s `--dry-run` takes `none | client | server`, and `--dry-run=none` is the default — it **executes for real**. So a write command such as `kubectl delete pod x --dry-run=none` was classified read-only (`"no"`) and **skipped the approval prompt** (`conversation.go`: `if result.ModifiesResourceStr != "no"`). The same bypass works with `--dry-run=false`, spaced `--dry-run none`, and empty `--dry-run=`.

## Fix

Parse the `--dry-run` value; only `client`/`server` (and the legacy boolean `true`) count as a dry run. `none`, `false`, empty, or unrecognized values are treated as real execution (fail-safe → require approval). Handles both `--dry-run=<v>` and spaced `--dry-run <v>`; bare `--dry-run` keeps its prior conservative treatment. No API change.

## Tests

Added table cases to `kubectl_filter_test.go` at both levels:
- `TestKubectlModifiesResource`: `--dry-run=none|false`, spaced `--dry-run none`, and empty `--dry-run=` on `delete`/`apply` now classify `"yes"`; existing `--dry-run=client|server|<bare>` cases stay `"no"`.
- `TestKubectlAnalyzerComponents`: the executing values yield `hasDryRun=false`.

The new cases fail on `main` and pass with this change.

## Note

This hardens a best-effort guardrail over the user's own kube-context — a defense-in-depth correctness fix, not a cross-boundary vulnerability.