### PR TITLE
feat: expose --log_file flag to customize the log destination

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -310,6 +310,9 @@ func run(ctx context.Context) error {
 	// We add just the klog flags we want, not all the klog flags (there are a lot, most of them are very niche)
 	rootCmd.PersistentFlags().AddGoFlag(klogFlags.Lookup("v"))
 	rootCmd.PersistentFlags().AddGoFlag(klogFlags.Lookup("alsologtostderr"))
+	// Expose log_file so the log destination is customizable instead of always
+	// <tmpdir>/kubectl-ai.log. Set --log_file=/dev/null to disable file logging.
+	rootCmd.PersistentFlags().AddGoFlag(klogFlags.Lookup("log_file"))
 
 	// do this early, before the third-party code logs anything.
 	redirectStdLogToKlog()


### PR DESCRIPTION
## What
Exposes the klog `log_file` flag so users can customize where `kubectl-ai` writes its log, instead of it always being `<tmpdir>/kubectl-ai.log`.

## Why
Fixes #428. The log destination was hard-set in `cmd/main.go`:

```go
klogFlags.Set("log_file", filepath.Join(os.TempDir(), "kubectl-ai.log"))
```

…but the `log_file` flag was never added to the command, so there was no way to change it. `v` and `alsologtostderr` are already surfaced the same way; this just adds `log_file` alongside them.

## Change
```go
rootCmd.PersistentFlags().AddGoFlag(klogFlags.Lookup("log_file"))
```

- Default is unchanged (`<tmpdir>/kubectl-ai.log`).
- Users can now set `--log_file=/path/to/kubectl-ai.log`, or `--log_file=/dev/null` to disable file logging (as the issue requests).

## Testing
`go build ./...` and `go vet ./...` pass. `kubectl-ai --help` now lists:

```
--log_file string   If non-empty, use this log file ... (default ".../kubectl-ai.log")
```