### PR TITLE
fix(agent): extract JSON from a bare ``` fence, not only ```json

### DIFF
--- a/pkg/agent/conversation.go
+++ b/pkg/agent/conversation.go
@@ -1290,16 +1290,25 @@ type Action struct {
 }
 
 func extractJSON(s string) (string, bool) {
-	const jsonBlockMarker = "```json"
+	// Prefer an explicit ```json fence, but fall back to a bare ``` fence:
+	// models don't always tag the language, and without the fallback the whole
+	// turn fails to parse.
+	if data, ok := extractFencedBlock(s, "```json"); ok {
+		return data, true
+	}
+	return extractFencedBlock(s, "```")
+}
 
-	first := strings.Index(s, jsonBlockMarker)
+// extractFencedBlock returns the content between the first occurrence of the
+// opening marker and the last ``` fence. The second return value is false when
+// no such block is present.
+func extractFencedBlock(s, opening string) (string, bool) {
+	first := strings.Index(s, opening)
 	last := strings.LastIndex(s, "```")
 	if first == -1 || last == -1 || first == last {
 		return "", false
 	}
-	data := s[first+len(jsonBlockMarker) : last]
-
-	return data, true
+	return s[first+len(opening) : last], true
 }
 
 // parseReActResponse parses the LLM response into a ReActResponse struct

--- a/pkg/agent/conversation_test.go
+++ b/pkg/agent/conversation_test.go
@@ -404,3 +404,82 @@ func TestAgent_NewSession_NoDeadlock(t *testing.T) {
 		t.Fatal("NewSession timed out (potential deadlock)")
 	}
 }
+
+func TestExtractJSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		wantData string
+		wantOK   bool
+	}{
+		{
+			name:     "json fenced block",
+			input:    "Here you go:\n```json\n{\"thought\":\"t\"}\n```\nthanks",
+			wantData: "\n{\"thought\":\"t\"}\n",
+			wantOK:   true,
+		},
+		{
+			name:     "bare fenced block (no language tag)",
+			input:    "```\n{\"thought\":\"t\"}\n```",
+			wantData: "\n{\"thought\":\"t\"}\n",
+			wantOK:   true,
+		},
+		{
+			name:   "no fence",
+			input:  "just some text without a code block",
+			wantOK: false,
+		},
+		{
+			name:   "empty string",
+			input:  "",
+			wantOK: false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			data, ok := extractJSON(tc.input)
+			if ok != tc.wantOK {
+				t.Fatalf("extractJSON ok = %v, want %v", ok, tc.wantOK)
+			}
+			if ok && data != tc.wantData {
+				t.Errorf("extractJSON data = %q, want %q", data, tc.wantData)
+			}
+		})
+	}
+}
+
+func TestParseReActResponse(t *testing.T) {
+	t.Run("json fence with action", func(t *testing.T) {
+		in := "```json\n{\"thought\":\"check pods\",\"action\":{\"name\":\"kubectl\",\"command\":\"get pods\"}}\n```"
+		got, err := parseReActResponse(in)
+		if err != nil {
+			t.Fatalf("parseReActResponse: %v", err)
+		}
+		if got.Thought != "check pods" || got.Action == nil || got.Action.Command != "get pods" {
+			t.Errorf("unexpected parse result: %+v", got)
+		}
+	})
+
+	t.Run("bare fence with action", func(t *testing.T) {
+		in := "```\n{\"thought\":\"done\",\"answer\":\"all good\"}\n```"
+		got, err := parseReActResponse(in)
+		if err != nil {
+			t.Fatalf("parseReActResponse: %v", err)
+		}
+		if got.Answer != "all good" {
+			t.Errorf("answer = %q, want %q", got.Answer, "all good")
+		}
+	})
+
+	t.Run("no code block errors", func(t *testing.T) {
+		if _, err := parseReActResponse("no block here"); err == nil {
+			t.Error("expected error for input without a code block")
+		}
+	})
+
+	t.Run("invalid json errors", func(t *testing.T) {
+		if _, err := parseReActResponse("```json\nnot json\n```"); err == nil {
+			t.Error("expected error for invalid JSON")
+		}
+	})
+}


### PR DESCRIPTION
## What
Makes the tool-use-shim response parser tolerant of a bare ` ``` ` code fence, not only ` ```json `. Adds unit tests for the (previously untested) `extractJSON` and `parseReActResponse` helpers.

## Why
For models without native function-calling, kubectl-ai uses a ReAct-style shim and parses the model's JSON out of a fenced code block via `extractJSON`:

```go
const jsonBlockMarker = "```json"
first := strings.Index(s, jsonBlockMarker)
```

It only recognized ` ```json `. But models frequently emit the JSON in a **bare** ` ``` ` block (no language tag). In that case `extractJSON` returned `false`, `parseReActResponse` errored, and the whole turn failed — even though the model produced a perfectly valid action.

## Change
`extractJSON` now falls back to a bare ` ``` ` fence when ` ```json ` is absent. The ` ```json ` path is **unchanged** (byte-for-byte), so existing behavior is preserved; this only adds a fallback.

## Testing
Adds `TestExtractJSON` and `TestParseReActResponse` (these helpers had no tests) covering the `json` fence, the new bare fence, and no-fence / invalid-JSON inputs. `go test ./pkg/agent/` and `go vet` pass.