### PR TITLE
feat(agent): add "enable-confirmations" meta-command to undo "don't ask me again"

### DIFF
--- a/pkg/agent/conversation.go
+++ b/pkg/agent/conversation.go
@@ -828,6 +828,15 @@ func (c *Agent) handleMetaQuery(ctx context.Context, query string) (answer strin
 	case "exit", "quit":
 		c.setAgentState(api.AgentStateExited)
 		return "It has been a pleasure assisting you. Have a great day!", true, nil
+	case "enable-confirmations":
+		// Undo a prior "Yes, and don't ask me again" choice (which sets
+		// SkipPermissions) so the agent resumes asking before commands that
+		// modify resources.
+		if !c.SkipPermissions {
+			return "Confirmations are already enabled.", true, nil
+		}
+		c.SkipPermissions = false
+		return "Confirmations re-enabled: you'll be asked before commands that modify resources.", true, nil
 	case "model":
 		return "Current model is `" + c.Model + "`", true, nil
 	case "models":

--- a/pkg/agent/conversation_test.go
+++ b/pkg/agent/conversation_test.go
@@ -404,3 +404,36 @@ func TestAgent_NewSession_NoDeadlock(t *testing.T) {
 		t.Fatal("NewSession timed out (potential deadlock)")
 	}
 }
+
+func TestHandleMetaQuery_EnableConfirmations(t *testing.T) {
+	ctx := context.Background()
+
+	// A prior "Yes, and don't ask me again" sets SkipPermissions; the meta
+	// command undoes it.
+	a := &Agent{SkipPermissions: true}
+	answer, handled, err := a.handleMetaQuery(ctx, "enable-confirmations")
+	if err != nil {
+		t.Fatalf("handleMetaQuery: %v", err)
+	}
+	if !handled {
+		t.Fatal("expected the query to be handled")
+	}
+	if a.SkipPermissions {
+		t.Error("SkipPermissions should be false after enable-confirmations")
+	}
+	if !strings.Contains(answer, "re-enabled") {
+		t.Errorf("unexpected answer: %q", answer)
+	}
+
+	// Idempotent: calling again when already enabled says so and stays false.
+	answer, handled, err = a.handleMetaQuery(ctx, "enable-confirmations")
+	if err != nil || !handled {
+		t.Fatalf("second call: handled=%v err=%v", handled, err)
+	}
+	if a.SkipPermissions {
+		t.Error("SkipPermissions should remain false")
+	}
+	if !strings.Contains(answer, "already enabled") {
+		t.Errorf("unexpected answer: %q", answer)
+	}
+}


### PR DESCRIPTION
## What
Adds an `enable-confirmations` meta-command that turns action confirmations back on after the user selected **"Yes, and don't ask me again"**.

## Why
Fixes #305. Selecting "Yes, and don't ask me again" at a confirmation prompt sets `SkipPermissions = true` for the rest of the session (`pkg/agent/conversation.go`), and there was no way to undo it short of restarting `kubectl-ai`. This adds a first-class way to re-enable the safety prompts mid-session.

## Change
New case in `handleMetaQuery`:

```
> enable-confirmations
Confirmations re-enabled: you'll be asked before commands that modify resources.
```

- Clears `SkipPermissions`, so the agent resumes prompting before resource-modifying commands.
- Idempotent — if confirmations are already on, it replies "Confirmations are already enabled." and changes nothing.

## Testing
Adds `TestHandleMetaQuery_EnableConfirmations` (covers the toggle-off and the already-enabled/idempotent path). `go build`, `go vet`, and `go test ./pkg/agent/` pass.