### PR TITLE
feat(ollama): add session persistence

### DIFF
--- a/gollm/ollama.go
+++ b/gollm/ollama.go
@@ -210,8 +210,56 @@ func (c *OllamaChat) SendStreaming(ctx context.Context, contents ...any) (ChatRe
 }
 
 func (c *OllamaChat) Initialize(messages []*kctlApi.Message) error {
-	klog.Warning("chat history persistence is not supported for provider 'ollama', using in-memory chat history")
+	history := make([]api.Message, 0, len(c.history)+len(messages))
+
+	// Ollama keeps the system prompt in its message history. Preserve it when
+	// replacing the conversation with a restored session or clearing a session.
+	for _, message := range c.history {
+		if message.Role == "system" {
+			history = append(history, message)
+		}
+	}
+
+	for _, message := range messages {
+		ollamaMessage, err := messageToOllama(message)
+		if err != nil {
+			continue
+		}
+		history = append(history, ollamaMessage)
+	}
+
+	c.history = history
 	return nil
+}
+
+func messageToOllama(message *kctlApi.Message) (api.Message, error) {
+	if message == nil {
+		return api.Message{}, fmt.Errorf("message is nil")
+	}
+
+	var role string
+	switch message.Source {
+	case kctlApi.MessageSourceUser:
+		role = "user"
+	case kctlApi.MessageSourceModel, kctlApi.MessageSourceAgent:
+		role = "assistant"
+	default:
+		return api.Message{}, fmt.Errorf("unknown message source: %s", message.Source)
+	}
+
+	if message.Type != kctlApi.MessageTypeText || message.Payload == nil {
+		return api.Message{}, fmt.Errorf("unsupported message type: %s", message.Type)
+	}
+
+	content, ok := message.Payload.(string)
+	if !ok {
+		content = fmt.Sprintf("%v", message.Payload)
+	}
+	if content == "" {
+		return api.Message{}, fmt.Errorf("message content is empty")
+	}
+
+	return api.Message{Role: role, Content: content}, nil
 }
 
 type OllamaChatResponse struct {

--- a/gollm/ollama_test.go
+++ b/gollm/ollama_test.go
@@ -1,0 +1,99 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gollm
+
+import (
+	"reflect"
+	"testing"
+
+	kctlApi "github.com/GoogleCloudPlatform/kubectl-ai/pkg/api"
+	"github.com/ollama/ollama/api"
+)
+
+func TestOllamaInitializeRestoresSupportedMessages(t *testing.T) {
+	chat := &OllamaChat{
+		history: []api.Message{
+			{Role: "system", Content: "system prompt"},
+			{Role: "user", Content: "stale message"},
+		},
+	}
+
+	messages := []*kctlApi.Message{
+		{Source: kctlApi.MessageSourceUser, Type: kctlApi.MessageTypeText, Payload: "list pods"},
+		{Source: kctlApi.MessageSourceModel, Type: kctlApi.MessageTypeText, Payload: "Here are the pods."},
+		{Source: kctlApi.MessageSourceAgent, Type: kctlApi.MessageTypeText, Payload: "Tool execution finished."},
+		{Source: kctlApi.MessageSourceUser, Type: kctlApi.MessageTypeText, Payload: 42},
+		{Source: kctlApi.MessageSourceUser, Type: kctlApi.MessageTypeError, Payload: "ignored error"},
+		{Source: kctlApi.MessageSource("unknown"), Type: kctlApi.MessageTypeText, Payload: "ignored source"},
+		{Source: kctlApi.MessageSourceUser, Type: kctlApi.MessageTypeText, Payload: ""},
+		{Source: kctlApi.MessageSourceUser, Type: kctlApi.MessageTypeText},
+		nil,
+	}
+
+	if err := chat.Initialize(messages); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+
+	want := []api.Message{
+		{Role: "system", Content: "system prompt"},
+		{Role: "user", Content: "list pods"},
+		{Role: "assistant", Content: "Here are the pods."},
+		{Role: "assistant", Content: "Tool execution finished."},
+		{Role: "user", Content: "42"},
+	}
+	if !reflect.DeepEqual(chat.history, want) {
+		t.Fatalf("Initialize() history = %#v, want %#v", chat.history, want)
+	}
+}
+
+func TestOllamaInitializeReplacesConversationAndPreservesSystemPrompt(t *testing.T) {
+	chat := &OllamaChat{
+		history: []api.Message{
+			{Role: "system", Content: "system prompt"},
+			{Role: "user", Content: "old user message"},
+			{Role: "assistant", Content: "old assistant message"},
+		},
+	}
+
+	first := []*kctlApi.Message{
+		{Source: kctlApi.MessageSourceUser, Type: kctlApi.MessageTypeText, Payload: "first restored message"},
+	}
+	if err := chat.Initialize(first); err != nil {
+		t.Fatalf("first Initialize() error = %v", err)
+	}
+
+	second := []*kctlApi.Message{
+		{Source: kctlApi.MessageSourceUser, Type: kctlApi.MessageTypeText, Payload: "replacement message"},
+	}
+	if err := chat.Initialize(second); err != nil {
+		t.Fatalf("second Initialize() error = %v", err)
+	}
+
+	want := []api.Message{
+		{Role: "system", Content: "system prompt"},
+		{Role: "user", Content: "replacement message"},
+	}
+	if !reflect.DeepEqual(chat.history, want) {
+		t.Fatalf("Initialize() history = %#v, want %#v", chat.history, want)
+	}
+
+	if err := chat.Initialize(nil); err != nil {
+		t.Fatalf("Initialize(nil) error = %v", err)
+	}
+	want = []api.Message{{Role: "system", Content: "system prompt"}}
+	if !reflect.DeepEqual(chat.history, want) {
+		t.Fatalf("Initialize(nil) history = %#v, want %#v", chat.history, want)
+	}
+}


### PR DESCRIPTION
## Summary

- restore persisted user, model, and agent messages into Ollama chat history
- preserve the configured Ollama system prompt while replacing stale conversation state
- skip unsupported or empty session records consistently with the other providers
- add regression coverage for role conversion, invalid records, repeated initialization, and session clearing

## Why

Ollama previously ignored persisted messages in `Initialize`, so loading or switching sessions could not restore the conversation. This converts stored API messages into Ollama messages while retaining the system prompt that Ollama keeps in its history.

## Validation

- `go test ./gollm -run '^TestOllama' -count=1`
- `go test -race ./gollm -run '^TestOllama' -count=1`
- `go test ./pkg/agent ./pkg/sessions -count=1`
- `go test ./... -count=1`
- `go test ./... -count=1` in `kubectl-utils`
- repository presubmits: build, vet, format, module tidiness, autogeneration, and mocks

Closes #464
