### PR TITLE
feat(mcp): add read-only server mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,6 +431,20 @@ Expose only kubectl-ai's native Kubernetes tools:
 kubectl-ai --mcp-server
 ```
 
+### Read-only MCP Server
+
+Expose only policy-checked kubectl inspection commands and omit `bash`:
+
+```bash
+kubectl-ai --mcp-server --mcp-read-only
+```
+
+The server validates the actual command immediately before execution. Commands
+that mutate resources or local kubeconfig state, compound shell commands, and
+commands whose effect cannot be classified are rejected. Read-only mode cannot
+be combined with `--external-tools`. Kubernetes RBAC remains the authority for
+which cluster data a caller may read.
+
 ### Enhanced MCP Server (With external tool discovery)
 
 Additionally discover and expose tools from other MCP servers as a unified interface:

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -94,6 +94,9 @@ type Options struct {
 	Quiet     bool `json:"quiet,omitempty"`
 	MCPServer bool `json:"mcpServer,omitempty"`
 	MCPClient bool `json:"mcpClient,omitempty"`
+	// MCPReadOnly exposes only kubectl commands that are proven not to mutate
+	// cluster or local kubeconfig state.
+	MCPReadOnly bool `json:"mcpReadOnly,omitempty"`
 	// ExternalTools enables discovery and exposure of external MCP tools (only works with --mcp-server)
 	ExternalTools bool `json:"externalTools,omitempty"`
 	MaxIterations int  `json:"maxIterations,omitempty"`
@@ -167,6 +170,7 @@ func (o *Options) InitDefaults() {
 	o.SkipPermissions = false
 	o.MCPServer = false
 	o.MCPClient = false
+	o.MCPReadOnly = false
 	// by default, external tools are disabled (only works with --mcp-server)
 	o.ExternalTools = false
 	// We now default to our strongest model (gemini-2.5-pro-exp-03-25) which supports tool use natively.
@@ -333,6 +337,7 @@ func (opt *Options) bindCLIFlags(f *pflag.FlagSet) error {
 	f.StringVar(&opt.ModelID, "model", opt.ModelID, "language model e.g. gemini-2.0-flash-thinking-exp-01-21, gemini-2.0-flash")
 	f.BoolVar(&opt.SkipPermissions, "skip-permissions", opt.SkipPermissions, "(dangerous) skip asking for confirmation before executing kubectl commands that modify resources")
 	f.BoolVar(&opt.MCPServer, "mcp-server", opt.MCPServer, "run in MCP server mode")
+	f.BoolVar(&opt.MCPReadOnly, "mcp-read-only", opt.MCPReadOnly, "expose only kubectl commands proven to be read-only (requires --mcp-server)")
 	f.BoolVar(&opt.ExternalTools, "external-tools", opt.ExternalTools, "in MCP server mode, discover and expose external MCP tools")
 	f.StringArrayVar(&opt.ToolConfigPaths, "custom-tools-config", opt.ToolConfigPaths, "path to custom tools config file or directory")
 	f.BoolVar(&opt.MCPClient, "mcp-client", opt.MCPClient, "enable MCP client mode to connect to external MCP servers")
@@ -364,6 +369,12 @@ func (opt *Options) bindCLIFlags(f *pflag.FlagSet) error {
 
 func RunRootCommand(ctx context.Context, opt Options, args []string) error {
 	var err error
+	if opt.MCPReadOnly && !opt.MCPServer {
+		return fmt.Errorf("--mcp-read-only requires --mcp-server")
+	}
+	if opt.MCPReadOnly && opt.ExternalTools {
+		return fmt.Errorf("--mcp-read-only cannot be combined with --external-tools")
+	}
 
 	// Automatically upgrade backend to filesystem if session persistence flags are requested explicitly
 	if (opt.NewSession || opt.ResumeSession != "" || opt.ListSessions || opt.DeleteSession != "") && opt.SessionBackend == "memory" {
@@ -728,7 +739,7 @@ func startMCPServer(ctx context.Context, opt Options) error {
 		klog.Warningf("--mcp-auth-issuer is set but --mcp-server-mode is %q; authentication only applies to streamable-http and will be ignored", opt.MCPServerMode)
 	}
 
-	mcpServer, err := newKubectlMCPServer(ctx, opt.KubeConfigPath, tools.Default(), workDir, opt.ExternalTools, opt.MCPServerMode, opt.HTTPPort, authConfig)
+	mcpServer, err := newKubectlMCPServer(ctx, opt.KubeConfigPath, tools.Default(), workDir, opt.ExternalTools, opt.MCPServerMode, opt.HTTPPort, authConfig, opt.MCPReadOnly)
 	if err != nil {
 		return fmt.Errorf("creating mcp server: %w", err)
 	}

--- a/cmd/mcp.go
+++ b/cmd/mcp.go
@@ -38,14 +38,28 @@ type kubectlMCPServer struct {
 	mcpServerMode string         // Server mode (e.g., "streamable-http", "stdio")
 	httpPort      int            // Port for HTTP-based server modes
 	authConfig    mcpauth.Config // OAuth 2.1 bearer auth (only used in streamable-http mode; disabled when Issuer is empty)
+	readOnly      bool
 }
 
-func newKubectlMCPServer(ctx context.Context, kubectlConfig string, t tools.Tools, workDir string, exposeExternalTools bool, serverMode string, httpPort int, authConfig mcpauth.Config) (*kubectlMCPServer, error) {
+func newKubectlMCPServer(ctx context.Context, kubectlConfig string, t tools.Tools, workDir string, exposeExternalTools bool, serverMode string, httpPort int, authConfig mcpauth.Config, readOnly bool) (*kubectlMCPServer, error) {
+	if readOnly && exposeExternalTools {
+		return nil, fmt.Errorf("read-only MCP mode cannot expose external tools")
+	}
+
 	// Register built-in tools (bash and kubectl) which require an executor.
 	// In MCP server mode, we use a local executor since there's no sandbox.
 	executor := sandbox.NewLocalExecutor()
-	t.RegisterTool(tools.NewBashTool(executor))
-	t.RegisterTool(tools.NewKubectlTool(executor))
+	if readOnly {
+		// Do not trust tools already present in the shared collection. A read-only
+		// server starts from an empty set and exposes only the restricted kubectl
+		// adapter.
+		t = tools.Tools{}
+		t.Init()
+		t.RegisterTool(tools.NewReadOnlyKubectlTool(executor))
+	} else {
+		t.RegisterTool(tools.NewBashTool(executor))
+		t.RegisterTool(tools.NewKubectlTool(executor))
+	}
 
 	s := &kubectlMCPServer{
 		kubectlConfig: kubectlConfig,
@@ -59,6 +73,7 @@ func newKubectlMCPServer(ctx context.Context, kubectlConfig string, t tools.Tool
 		mcpServerMode: serverMode,
 		httpPort:      httpPort,
 		authConfig:    authConfig,
+		readOnly:      readOnly,
 	}
 
 	// Add built-in tools
@@ -246,6 +261,19 @@ func (s *kubectlMCPServer) handleBuiltinToolCall(ctx context.Context, request mc
 				},
 			},
 		}, nil
+	}
+	if s.readOnly {
+		if tool.Name() != "kubectl" || tool.CheckModifiesResource(args) != "no" {
+			return &mcpgo.CallToolResult{
+				IsError: true,
+				Content: []mcpgo.Content{
+					mcpgo.TextContent{
+						Type: "text",
+						Text: fmt.Sprintf("read-only MCP server rejected tool %q because the operation could not be proven read-only", tool.Name()),
+					},
+				},
+			}, nil
+		}
 	}
 
 	// Execute the built-in tool

--- a/cmd/mcp_test.go
+++ b/cmd/mcp_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"strings"
 	"testing"
 	"time"
 
@@ -25,7 +26,62 @@ import (
 	"github.com/GoogleCloudPlatform/kubectl-ai/pkg/mcp"
 	"github.com/GoogleCloudPlatform/kubectl-ai/pkg/mcpauth"
 	"github.com/GoogleCloudPlatform/kubectl-ai/pkg/tools"
+	mcpgo "github.com/mark3labs/mcp-go/mcp"
 )
+
+func TestMCPReadOnlyServerExposesOnlyKubectlAndBlocksMutation(t *testing.T) {
+	toolset := tools.Tools{}
+	toolset.Init()
+	toolset.RegisterTool(&stubTool{})
+
+	server, err := newKubectlMCPServer(context.Background(), "", toolset, t.TempDir(), false, "stdio", 0, mcpauth.Config{}, true)
+	if err != nil {
+		t.Fatalf("newKubectlMCPServer: %v", err)
+	}
+	if got := server.tools.Names(); len(got) != 1 || got[0] != "kubectl" {
+		t.Fatalf("read-only MCP tools = %v, want [kubectl]", got)
+	}
+
+	kubectlTool := server.tools.Lookup("kubectl")
+	result, err := server.handleBuiltinToolCall(context.Background(), mcpgo.CallToolRequest{
+		Params: mcpgo.CallToolParams{
+			Name: "kubectl",
+			Arguments: map[string]any{
+				"command":           "kubectl delete pod api",
+				"modifies_resource": "no",
+			},
+		},
+	}, kubectlTool)
+	if err != nil {
+		t.Fatalf("handleBuiltinToolCall: %v", err)
+	}
+	if !result.IsError || len(result.Content) == 0 || !strings.Contains(fmt.Sprint(result.Content[0]), "could not be proven read-only") {
+		t.Fatalf("mutating call was not rejected: %+v", result)
+	}
+}
+
+func TestMCPReadOnlyServerRejectsExternalTools(t *testing.T) {
+	toolset := tools.Tools{}
+	toolset.Init()
+	if _, err := newKubectlMCPServer(context.Background(), "", toolset, t.TempDir(), true, "stdio", 0, mcpauth.Config{}, true); err == nil {
+		t.Fatal("read-only MCP server accepted external tools")
+	}
+}
+
+func TestMCPReadOnlyFlagValidation(t *testing.T) {
+	var opt Options
+	opt.InitDefaults()
+	opt.MCPReadOnly = true
+	if err := RunRootCommand(context.Background(), opt, nil); err == nil || !strings.Contains(err.Error(), "requires --mcp-server") {
+		t.Fatalf("MCP read-only without server error = %v", err)
+	}
+
+	opt.MCPServer = true
+	opt.ExternalTools = true
+	if err := RunRootCommand(context.Background(), opt, nil); err == nil || !strings.Contains(err.Error(), "cannot be combined") {
+		t.Fatalf("MCP read-only with external tools error = %v", err)
+	}
+}
 
 func TestKubectlMCPServerHTTPClientIntegration(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
@@ -39,7 +95,7 @@ func TestKubectlMCPServerHTTPClientIntegration(t *testing.T) {
 
 	workDir := t.TempDir()
 
-	server, err := newKubectlMCPServer(ctx, "", toolset, workDir, false, "streamable-http", port, mcpauth.Config{})
+	server, err := newKubectlMCPServer(ctx, "", toolset, workDir, false, "streamable-http", port, mcpauth.Config{}, false)
 	if err != nil {
 		t.Fatalf("failed to create MCP server: %v", err)
 	}

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -15,6 +15,24 @@ Start the MCP server with only kubectl-ai's built-in tools:
 kubectl-ai --mcp-server
 ```
 
+### Read-only MCP Server
+
+Start a server that exposes only a restricted kubectl tool:
+
+```bash
+kubectl-ai --mcp-server --mcp-read-only
+```
+
+This mode does not register `bash`, custom tools, or external MCP tools. Before
+each execution it independently classifies the actual kubectl command and
+rejects mutations, local kubeconfig changes, compound commands, and ambiguous
+operations. The client-provided `modifies_resource` argument is not trusted.
+
+The boundary prevents writes; it does not decide which data is appropriate for
+a caller to see. Use a dedicated Kubernetes service account and RBAC rules to
+limit readable namespaces and resources. When using the HTTP transport, enable
+OAuth authentication as described below.
+
 ### Enhanced MCP Server (With external tool discovery)
 
 Start the MCP server with external MCP tool discovery enabled:
@@ -217,6 +235,8 @@ kubectl-ai provides the following native tools:
 - `bash`: Executes a bash command. Use this tool only when you need to execute a shell command.
 - `kubectl`: Executes a kubectl command against the user's Kubernetes cluster. Use this tool only when you need to query or modify the state of the user's Kubernetes cluster.
 
+With `--mcp-read-only`, only the restricted `kubectl` tool is exposed.
+
 ### External Tools (when `--external-tools` is enabled)
 
 Additional tools are available depending on the configured MCP servers:
@@ -232,7 +252,8 @@ Additional tools are available depending on the configured MCP servers:
 | Flag                  | Default          | Description                                                                                                           |
 | --------------------- | ---------------- | --------------------------------------------------------------------------------------------------------------------- |
 | `--mcp-server`        | `false`          | Run in MCP server mode                                                                                                |
-| `--external-tools`    | `false`          | Discover and expose external MCP tools (requires --mcp-server)                                                        |
+| `--mcp-read-only`     | `false`          | Expose only kubectl commands proven read-only (requires `--mcp-server`)                                               |
+| `--external-tools`    | `false`          | Discover and expose external MCP tools (incompatible with `--mcp-read-only`)                                          |
 | `--kubeconfig`        | `~/.kube/config` | Path to kubeconfig file                                                                                               |
 | `--mcp-server-mode`   | `stdio`          | Transport for the MCP server (`stdio` or `streamable-http`)                                                           |
 | `--http-port`         | `9080`           | Port for the HTTP endpoint when using `streamable-http` modes                                                         |

--- a/pkg/tools/kubectl_filter.go
+++ b/pkg/tools/kubectl_filter.go
@@ -15,6 +15,7 @@
 package tools
 
 import (
+	"path/filepath"
 	"strings"
 
 	"k8s.io/klog/v2"
@@ -26,11 +27,10 @@ var (
 	readOnlyOps = map[string]bool{
 		"get": true, "describe": true, "explain": true, "top": true,
 		"logs": true, "api-resources": true, "api-versions": true,
-		"version": true, "config": true, "cluster-info": true,
-		"wait": true, "auth": true, "diff": true, "kustomize": true,
-		"help": true, "options": true, "proxy": true,
+		"version": true, "cluster-info": true,
+		"wait": true, "diff": true, "kustomize": true,
+		"help": true, "options": true,
 		"completion": true, "convert": true, "events": true,
-		"port-forward": true, "can-i": true, "whoami": true,
 	}
 
 	writeOps = map[string]bool{
@@ -48,6 +48,17 @@ var (
 			"history": true,
 			"status":  true,
 		},
+		"config": {
+			"current-context": true,
+			"get-clusters":    true,
+			"get-contexts":    true,
+			"get-users":       true,
+			"view":            true,
+		},
+		"auth": {
+			"can-i":  true,
+			"whoami": true,
+		},
 	}
 
 	writeSubOps = map[string]map[string]bool{
@@ -56,6 +67,21 @@ var (
 			"restart": true,
 			"resume":  true,
 			"undo":    true,
+		},
+		"config": {
+			"delete-cluster":  true,
+			"delete-context":  true,
+			"delete-user":     true,
+			"rename-context":  true,
+			"set":             true,
+			"set-cluster":     true,
+			"set-context":     true,
+			"set-credentials": true,
+			"unset":           true,
+			"use-context":     true,
+		},
+		"auth": {
+			"reconcile": true,
 		},
 	}
 )
@@ -119,7 +145,53 @@ func kubectlModifiesResource(command string) string {
 	return "unknown"
 }
 
+// kubectlReadOnlyEffect accepts only one plain kubectl invocation. It rejects
+// shell features that can change local state or alter what is actually
+// executed, and it does not treat dry-run writes as read-only. It is used by
+// the MCP read-only tool, where commands execute unattended on the server.
+func kubectlReadOnlyEffect(command string) string {
+	parser := syntax.NewParser()
+	file, err := parser.Parse(strings.NewReader(command), "")
+	if err != nil {
+		return "unknown"
+	}
+
+	if len(file.Stmts) != 1 {
+		return "unknown"
+	}
+
+	stmt := file.Stmts[0]
+	if stmt.Negated || stmt.Background || stmt.Coprocess || stmt.Semicolon.IsValid() || len(stmt.Redirs) != 0 {
+		return "unknown"
+	}
+
+	call, ok := stmt.Cmd.(*syntax.CallExpr)
+	if !ok || len(call.Assigns) != 0 {
+		return "unknown"
+	}
+
+	// A command substitution or process substitution contains another call.
+	// Reject it even when the outer kubectl verb itself is read-only.
+	hasNestedCall := false
+	syntax.Walk(call, func(node syntax.Node) bool {
+		if nested, ok := node.(*syntax.CallExpr); ok && nested != call {
+			hasNestedCall = true
+			return false
+		}
+		return true
+	})
+	if hasNestedCall {
+		return "unknown"
+	}
+
+	return analyzeCallWithPolicy(call, false)
+}
+
 func analyzeCall(call *syntax.CallExpr) string {
+	return analyzeCallWithPolicy(call, true)
+}
+
+func analyzeCallWithPolicy(call *syntax.CallExpr, allowDryRunWrites bool) string {
 	if call == nil || len(call.Args) == 0 {
 		klog.Warning("analyzeCall: call is nil or has no args")
 		return "unknown"
@@ -153,8 +225,10 @@ func analyzeCall(call *syntax.CallExpr) string {
 		return "unknown"
 	}
 
-	// Check if this is kubectl
-	if !strings.Contains(firstArg, "kubectl") {
+	// Match only the actual kubectl executable. A substring check would accept
+	// lookalikes such as kubectl.wrapper and make read-only enforcement bypassable.
+	base := filepath.Base(firstArg)
+	if base != "kubectl" && base != "kubectl.exe" {
 		klog.V(2).Infof("analyzeCall: first arg does not contain kubectl: %q", firstArg)
 		return "unknown"
 	}
@@ -181,13 +255,13 @@ func analyzeCall(call *syntax.CallExpr) string {
 	}
 
 	// Check standard operations - write operations first (prioritize immediate detection)
-	if (writeOps[verb] || writeSubOps[verb][subVerb]) && !hasDryRun {
+	if (writeOps[verb] || writeSubOps[verb][subVerb]) && (!hasDryRun || !allowDryRunWrites) {
 		klog.V(1).Infof("analyzeCall: write op for verb=%q subVerb=%q", verb, subVerb)
 		return "yes"
 	}
 
 	// Check read-only operations or dry-run write operations
-	if (readOnlyOps[verb] || readOnlySubOps[verb][subVerb]) || ((writeOps[verb] || writeSubOps[verb][subVerb]) && hasDryRun) {
+	if (readOnlyOps[verb] || readOnlySubOps[verb][subVerb]) || (allowDryRunWrites && (writeOps[verb] || writeSubOps[verb][subVerb]) && hasDryRun) {
 		klog.V(1).Infof("analyzeCall: read op for verb=%q subVerb=%q (dry-run=%v)", verb, subVerb, hasDryRun)
 		return "no"
 	}

--- a/pkg/tools/kubectl_filter_test.go
+++ b/pkg/tools/kubectl_filter_test.go
@@ -32,10 +32,10 @@ func TestKubectlModifiesResource(t *testing.T) {
 		"read-only commands": {
 			{"Get pods", "kubectl get pods", "no"},
 			{"Describe pod", "kubectl describe pod nginx", "no"},
-			{"Port-forward", "kubectl port-forward pod/nginx 8080:80", "no"},
-			{"Port-forward with service", "kubectl port-forward svc/nginx 8080:80", "no"},
-			{"Port-forward complex", "kubectl port-forward deployment/myapp 8080:8080 9000:9000", "no"},
-			{"Port-forward background", "kubectl port-forward svc/nginx 8080:80 &", "no"},
+			{"Port-forward", "kubectl port-forward pod/nginx 8080:80", "unknown"},
+			{"Port-forward with service", "kubectl port-forward svc/nginx 8080:80", "unknown"},
+			{"Port-forward complex", "kubectl port-forward deployment/myapp 8080:8080 9000:9000", "unknown"},
+			{"Port-forward background", "kubectl port-forward svc/nginx 8080:80 &", "unknown"},
 			{"Get with output", "kubectl get pods -o yaml", "no"},
 			{"Get with output redirection", "kubectl get pods > pods.txt", "no"},
 			{"Get with name", "kubectl get pod nginx", "no"},
@@ -70,12 +70,13 @@ func TestKubectlModifiesResource(t *testing.T) {
 			{"Exec into pod", "kubectl exec -n demo tgi-pod -- nvidia-smi", "yes"},
 			{"Taint node", "kubectl taint nodes node1 key=value:NoSchedule", "yes"},
 			{"Run pod", "kubectl run nginx --image=nginx", "yes"},
-			{"Config set-context", "kubectl config set-context my-context", "no"},
+			{"Config set-context", "kubectl config set-context my-context", "yes"},
 			{"Exec command", "kubectl exec nginx -- rm -rf /", "yes"},
 			{"Cordon node", "kubectl cordon node1", "yes"},
 			{"Uncordon node", "kubectl uncordon node1", "yes"},
 			{"Drain node", "kubectl drain node1", "yes"},
 			{"Certificate approve", "kubectl certificate approve csr-12345", "yes"},
+			{"Auth reconcile", "kubectl auth reconcile -f rbac.yaml", "yes"},
 		},
 		"special cases": {
 			{"Dry run create", "kubectl create -f pod.yaml --dry-run=client", "no"},
@@ -101,6 +102,7 @@ func TestKubectlModifiesResource(t *testing.T) {
 			{"Mix safe and unsafe with result", "kubectl get pods && kubectl delete pod bad-pod", "yes"},
 			{"Mix with initial unsafe", "kubectl delete pod bad-pod && kubectl get pods", "yes"},
 			{"Kubectl alias k", "k get pods", "unknown"},
+			{"Kubectl lookalike", "kubectl.wrapper get pods", "unknown"},
 			{"Full path with arguments", "/usr/local/custom/kubectl --kubeconfig=/path/config get pods", "no"},
 			{"Complex jsonpath", "kubectl get pods -o=jsonpath='{range .items[*]}{.metadata.name}{\"\\t\"}{.status.phase}{\"\\n\"}{end}'", "no"},
 			{"Custom columns", "kubectl get pods -o=custom-columns=NAME:.metadata.name,STATUS:.status.phase", "no"},
@@ -118,11 +120,11 @@ func TestKubectlModifiesResource(t *testing.T) {
 			{"Field manager", "kubectl apply -f deploy.yaml --field-manager=controller", "yes"},
 			{"Create service account", "kubectl create serviceaccount jenkins", "yes"},
 			{"Create role binding", "kubectl create rolebinding admin --clusterrole=admin --user=user1 --namespace=default", "yes"},
-			{"Versioned kubectl", "kubectl.1.24 get pods", "no"},
-			{"Config set credentials", "kubectl config set-credentials cluster-admin --token=secret", "no"},
+			{"Versioned kubectl", "kubectl.1.24 get pods", "unknown"},
+			{"Config set credentials", "kubectl config set-credentials cluster-admin --token=secret", "yes"},
 			{"Config view with flatten", "kubectl config view --flatten", "no"},
 			{"Config view with output", "kubectl config view -o json", "no"},
-			{"Config use-context", "kubectl config use-context production", "no"},
+			{"Config use-context", "kubectl config use-context production", "yes"},
 			{"Label with special characters", "kubectl label pod nginx 'app.kubernetes.io/name=nginx-controller'", "yes"},
 			{"Jsonpath with quotes", "kubectl get pods -o jsonpath='{.items[0].metadata.name}'", "no"},
 			{"Command with grep", "kubectl get pods | grep -v Completed", "unknown"},
@@ -133,7 +135,7 @@ func TestKubectlModifiesResource(t *testing.T) {
 			{"Multiple input files", "kubectl delete -f file1.yaml -f file2.yaml", "yes"},
 			{"URL as input file", "kubectl apply -f https://example.com/manifest.yaml", "yes"},
 			{"Input from stdin", "cat file.yaml | kubectl apply -f -", "yes"},
-			{"Proxy command", "kubectl proxy --port=8080", "no"},
+			{"Proxy command", "kubectl proxy --port=8080", "unknown"},
 			{"Attach command", "kubectl attach mypod -i", "yes"},
 			{"Copy files", "kubectl cp mypod:/tmp/foo /tmp/bar", "yes"},
 			{"Rollout status with flags", "kubectl rollout --recursive=false status --timeout=0s deployment -w nginx", "no"},
@@ -150,6 +152,39 @@ func TestKubectlModifiesResource(t *testing.T) {
 							tt.command, result, tt.expected)
 					}
 				})
+			}
+		})
+	}
+}
+
+func TestReadOnlyKubectlRejectsShellAndLocalSideEffects(t *testing.T) {
+	tool := NewReadOnlyKubectlTool(nil)
+	tests := []struct {
+		name    string
+		command string
+		allowed bool
+	}{
+		{name: "get", command: "kubectl get pods", allowed: true},
+		{name: "logs", command: "kubectl logs deployment/api --tail=100", allowed: true},
+		{name: "dry run mutation", command: "kubectl apply -f deployment.yaml --dry-run=server", allowed: false},
+		{name: "delete", command: "kubectl delete pod api", allowed: false},
+		{name: "kubeconfig mutation", command: "kubectl config use-context production", allowed: false},
+		{name: "lookalike", command: "kubectl.wrapper get pods", allowed: false},
+		{name: "compound", command: "kubectl get pods | grep api", allowed: false},
+		{name: "redirect", command: "kubectl get pods > /tmp/pods", allowed: false},
+		{name: "background", command: "kubectl get pods &", allowed: false},
+		{name: "environment override", command: "KUBECONFIG=/tmp/other kubectl get pods", allowed: false},
+		{name: "command substitution", command: "kubectl get pod $(touch /tmp/changed)", allowed: false},
+		{name: "subshell", command: "(kubectl get pods)", allowed: false},
+		{name: "loop", command: "for ns in default; do kubectl get pods -n $ns; done", allowed: false},
+		{name: "proxy", command: "kubectl proxy --port=8080", allowed: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tool.CheckModifiesResource(map[string]any{"command": tt.command}) == "no"
+			if got != tt.allowed {
+				t.Fatalf("read-only classification for %q = %v, want %v", tt.command, got, tt.allowed)
 			}
 		})
 	}
@@ -235,7 +270,7 @@ func TestKubectlCommandParsing(t *testing.T) {
 
 		// Non-kubectl commands
 		{"not kubectl", "k get pods", "unknown", "kubectl alias"},
-		{"kubectl suffix", "kubectl-1.28 get pods", "no", "kubectl with version suffix"},
+		{"kubectl suffix", "kubectl-1.28 get pods", "unknown", "kubectl with version suffix"},
 		{"kubectl prefix", "kubectl-proxy --port=8080", "unknown", "kubectl with additional suffix"},
 		{"different command", "kubectx production", "unknown", "different k8s tool"},
 

--- a/pkg/tools/kubectl_tool.go
+++ b/pkg/tools/kubectl_tool.go
@@ -28,8 +28,57 @@ type Kubectl struct {
 	executor sandbox.Executor
 }
 
+// ReadOnlyKubectl uses the kubectl executor but advertises only inspection
+// operations. MCP enforcement still validates the actual command immediately
+// before execution; this schema is guidance, not the security boundary.
+type ReadOnlyKubectl struct {
+	*Kubectl
+}
+
 func NewKubectlTool(executor sandbox.Executor) *Kubectl {
 	return &Kubectl{executor: executor}
+}
+
+func NewReadOnlyKubectlTool(executor sandbox.Executor) *ReadOnlyKubectl {
+	return &ReadOnlyKubectl{Kubectl: NewKubectlTool(executor)}
+}
+
+func (t *ReadOnlyKubectl) Description() string {
+	return `Executes a single read-only kubectl inspection command. Mutating, ambiguous, compound, and kubeconfig-changing commands are rejected before execution.`
+}
+
+func (t *ReadOnlyKubectl) FunctionDefinition() *gollm.FunctionDefinition {
+	return &gollm.FunctionDefinition{
+		Name:        t.Name(),
+		Description: t.Description(),
+		Parameters: &gollm.Schema{
+			Type: gollm.TypeObject,
+			Properties: map[string]*gollm.Schema{
+				"command": {
+					Type: gollm.TypeString,
+					Description: `A single read-only kubectl command with the kubectl prefix.
+
+Examples:
+- kubectl get pods --all-namespaces
+- kubectl describe pod api-0 --namespace=demo
+- kubectl logs deployment/api --namespace=demo --tail=200
+- kubectl events --namespace=demo
+- kubectl top pods --namespace=demo`,
+				},
+			},
+		},
+	}
+}
+
+// CheckModifiesResource applies a stricter boundary than the interactive
+// permission classifier: shell redirection and background execution can change
+// local server state even when the kubectl verb itself is read-only.
+func (t *ReadOnlyKubectl) CheckModifiesResource(args map[string]any) string {
+	command, ok := args["command"].(string)
+	if !ok {
+		return "unknown"
+	}
+	return kubectlReadOnlyEffect(command)
 }
 
 func (t *Kubectl) Name() string {


### PR DESCRIPTION
## Summary

- add `--mcp-read-only` for MCP server mode
- expose only a restricted `kubectl` tool; omit `bash`, custom tools, and external MCP tools
- revalidate the actual command immediately before execution instead of trusting client-supplied `modifies_resource`
- fail closed for mutations (including dry-run), kubeconfig changes, ambiguous or compound shell commands, redirection, background execution, environment overrides, nested commands, and lookalike executables
- document Kubernetes RBAC and HTTP authentication requirements

## Testing

- `go test ./...`
- `go vet ./...`
- all current presubmit scripts: build, vet, autogen, format, Go modules, and mocks
- 14 table-driven read-only boundary cases plus MCP tool-isolation and flag-validation tests

Fixes #508