### PR TITLE
fix: redact sensitive headers from the trace file

### DIFF
--- a/gollm/http_journal.go
+++ b/gollm/http_journal.go
@@ -19,11 +19,65 @@ import (
 	"io"
 	"net/http"
 	"net/http/httputil"
+	"regexp"
+	"strings"
 
 	"github.com/GoogleCloudPlatform/kubectl-ai/pkg/journal"
 
 	"k8s.io/klog/v2"
 )
+
+// sensitiveHeaders lists the header names (case-insensitive) that carry
+// credentials or session identifiers across the LLM providers this package
+// talks to (goog-api-key for Gemini, Authorization for OpenAI/Grok bearer
+// tokens, x-api-key for Anthropic, api-key for Azure OpenAI), plus the
+// generic HTTP auth/session headers. Their values must never reach the
+// trace file.
+var sensitiveHeaders = map[string]bool{
+	"authorization":       true,
+	"proxy-authorization": true,
+	"x-api-key":           true,
+	"x-goog-api-key":      true,
+	"api-key":             true,
+	"cookie":              true,
+	"set-cookie":          true,
+}
+
+const redactedValue = "REDACTED"
+
+// sensitiveHeaderLine matches a single HTTP header line, as produced by
+// httputil.DumpRequestOut, whose name is one of sensitiveHeaders.
+var sensitiveHeaderLine = regexp.MustCompile(`(?im)^(` + sensitiveHeaderNamesPattern() + `):.*$`)
+
+func sensitiveHeaderNamesPattern() string {
+	pattern := ""
+	for name := range sensitiveHeaders {
+		if pattern != "" {
+			pattern += "|"
+		}
+		pattern += regexp.QuoteMeta(name)
+	}
+	return pattern
+}
+
+// redactSensitiveHeaderLines redacts the value of any sensitive header found
+// in a raw HTTP request/response dump (e.g. from httputil.DumpRequestOut),
+// leaving the header name and every other line untouched.
+func redactSensitiveHeaderLines(dump []byte) []byte {
+	return sensitiveHeaderLine.ReplaceAll(dump, []byte("$1: "+redactedValue))
+}
+
+// redactSensitiveHeaderValues returns a copy of headers with the value of
+// any sensitive header replaced, leaving non-sensitive headers untouched.
+func redactSensitiveHeaderValues(headers http.Header) http.Header {
+	redacted := headers.Clone()
+	for name := range redacted {
+		if sensitiveHeaders[strings.ToLower(name)] {
+			redacted[name] = []string{redactedValue}
+		}
+	}
+	return redacted
+}
 
 // journalingRoundTripper wraps an existing http.RoundTripper to record requests and responses.
 type journalingRoundTripper struct {
@@ -41,7 +95,7 @@ func (jrt *journalingRoundTripper) RoundTrip(req *http.Request) (*http.Response,
 	if err == nil {
 		err = recorder.Write(req.Context(), &journal.Event{
 			Action:  journal.ActionHTTPRequest,
-			Payload: map[string]any{"request": string(reqBytes)},
+			Payload: map[string]any{"request": string(redactSensitiveHeaderLines(reqBytes))},
 		})
 		if err != nil {
 			klog.Errorf("Error writing outgoing request to journal: %v", err)
@@ -74,7 +128,7 @@ func (jrt *journalingRoundTripper) RoundTrip(req *http.Request) (*http.Response,
 	// Default payload is the raw body, for non-streaming responses.
 	logPayload := map[string]any{
 		"status":  resp.Status,
-		"headers": resp.Header,
+		"headers": redactSensitiveHeaderValues(resp.Header),
 		"body":    string(bodyBytes),
 	}
 

--- a/gollm/http_journal_test.go
+++ b/gollm/http_journal_test.go
@@ -1,0 +1,140 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gollm
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/kubectl-ai/pkg/journal"
+)
+
+// fakeRoundTripper returns a canned response without making a real network call.
+type fakeRoundTripper struct{}
+
+func (f *fakeRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: 200,
+		Status:     "200 OK",
+		Header: http.Header{
+			"Content-Type": []string{"application/json"},
+			"Set-Cookie":   []string{"session=super-secret-session-cookie"},
+			"X-Request-Id": []string{"abc-123"},
+		},
+		Body: io.NopCloser(strings.NewReader(`{"ok":true}`)),
+	}, nil
+}
+
+// capturingRecorder collects every event written to it, for assertions.
+type capturingRecorder struct {
+	events []*journal.Event
+}
+
+func (c *capturingRecorder) Write(_ context.Context, event *journal.Event) error {
+	c.events = append(c.events, event)
+	return nil
+}
+
+func (c *capturingRecorder) Close() error { return nil }
+
+func TestJournalingRoundTripper_RedactsSensitiveRequestHeaders(t *testing.T) {
+	recorder := &capturingRecorder{}
+	ctx := journal.ContextWithRecorder(context.Background(), recorder)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "https://generativelanguage.googleapis.com/v1/models", bytes.NewReader([]byte(`{}`)))
+	if err != nil {
+		t.Fatalf("building request: %v", err)
+	}
+	req.Header.Set("X-Goog-Api-Key", "AIzaSyTHIS-IS-A-SECRET-GEMINI-KEY")
+	req.Header.Set("Authorization", "Bearer sk-THIS-IS-A-SECRET-OPENAI-KEY")
+	req.Header.Set("X-Api-Key", "sk-ant-THIS-IS-A-SECRET-ANTHROPIC-KEY")
+	req.Header.Set("Api-Key", "THIS-IS-A-SECRET-AZURE-KEY")
+	req.Header.Set("Content-Type", "application/json")
+
+	rt := &journalingRoundTripper{next: &fakeRoundTripper{}}
+	if _, err := rt.RoundTrip(req); err != nil {
+		t.Fatalf("RoundTrip returned error: %v", err)
+	}
+
+	var requestDump string
+	for _, e := range recorder.events {
+		if e.Action == journal.ActionHTTPRequest {
+			requestDump, _ = e.GetString("request")
+		}
+	}
+	if requestDump == "" {
+		t.Fatal("no http.request event captured")
+	}
+
+	for _, secret := range []string{
+		"AIzaSyTHIS-IS-A-SECRET-GEMINI-KEY",
+		"sk-THIS-IS-A-SECRET-OPENAI-KEY",
+		"sk-ant-THIS-IS-A-SECRET-ANTHROPIC-KEY",
+		"THIS-IS-A-SECRET-AZURE-KEY",
+	} {
+		if strings.Contains(requestDump, secret) {
+			t.Errorf("recorded request dump leaked secret %q:\n%s", secret, requestDump)
+		}
+	}
+
+	// Non-sensitive headers must still be visible, so the trace stays useful.
+	if !strings.Contains(requestDump, "application/json") {
+		t.Errorf("recorded request dump lost a non-sensitive header:\n%s", requestDump)
+	}
+}
+
+func TestJournalingRoundTripper_RedactsSensitiveResponseHeaders(t *testing.T) {
+	recorder := &capturingRecorder{}
+	ctx := journal.ContextWithRecorder(context.Background(), recorder)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "https://example.com", bytes.NewReader([]byte(`{}`)))
+	if err != nil {
+		t.Fatalf("building request: %v", err)
+	}
+
+	rt := &journalingRoundTripper{next: &fakeRoundTripper{}}
+	if _, err := rt.RoundTrip(req); err != nil {
+		t.Fatalf("RoundTrip returned error: %v", err)
+	}
+
+	var payload map[string]any
+	for _, e := range recorder.events {
+		if e.Action == journal.ActionHTTPResponse {
+			p, ok := e.Payload.(map[string]any)
+			if !ok {
+				t.Fatalf("unexpected payload type: %T", e.Payload)
+			}
+			payload = p
+		}
+	}
+	if payload == nil {
+		t.Fatal("no http.response event captured")
+	}
+
+	headers, ok := payload["headers"].(http.Header)
+	if !ok {
+		t.Fatalf("unexpected headers type: %T", payload["headers"])
+	}
+	if got := headers.Get("Set-Cookie"); strings.Contains(got, "super-secret-session-cookie") {
+		t.Errorf("recorded response headers leaked Set-Cookie value: %q", got)
+	}
+	if got := headers.Get("X-Request-Id"); got != "abc-123" {
+		t.Errorf("recorded response headers lost a non-sensitive header, got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

`journalingRoundTripper.RoundTrip` (`gollm/http_journal.go`) writes the full raw HTTP request via `httputil.DumpRequestOut(req, true)` into the trace file, including every header — whichever credential header the active provider's SDK set (`X-Goog-Api-Key` for Gemini, `Authorization: Bearer ...` for OpenAI/Grok, `X-Api-Key` for Anthropic, `Api-Key` for Azure OpenAI). Response headers (e.g. `Set-Cookie`) are logged the same way, unfiltered. A trace file shared for debugging (`--trace-path`) leaks whatever key was in use.

Fixes #617

## Change

- Redact the value of known credential/session headers (`Authorization`, `Proxy-Authorization`, `X-Api-Key`, `X-Goog-Api-Key`, `Api-Key`, `Cookie`, `Set-Cookie`) before writing the request dump and response header map to the journal.
- Request side: a regex pass over the raw `httputil.DumpRequestOut` bytes, replacing only the matched header line's value — every other header and the request body stay untouched.
- Response side: a shallow copy of `resp.Header` with only the sensitive keys' values replaced, since it's already structured (`http.Header`).
- Non-sensitive headers (`Content-Type`, `X-Request-Id`, etc.) are left exactly as before, so the trace stays useful for debugging.

## Testing Plan

- Added `gollm/http_journal_test.go`:
  - `TestJournalingRoundTripper_RedactsSensitiveRequestHeaders`: sets all four provider credential header shapes on a request, asserts none of the secret values appear anywhere in the recorded `http.request` journal event, and that a non-sensitive header (`Content-Type`) is still visible.
  - `TestJournalingRoundTripper_RedactsSensitiveResponseHeaders`: asserts a `Set-Cookie` value is redacted from the recorded `http.response` event's headers while a non-sensitive header (`X-Request-Id`) survives.
- Verified RED: both tests fail against pre-fix code, reproducing the leak (confirmed the secret values are present verbatim in the dump).
- Verified GREEN: both new tests pass after the fix.
- `go build ./...` and `go vet ./...` clean in `gollm/`.
- Full `gollm` module test suite run: two pre-existing failures (`TestGetAnthropicModel/explicit_model_is_highest_priority`, `TestNewClient`) reproduce identically on unmodified `main` (confirmed via `git stash`) — unrelated to this change, looks like env-var leakage between tests in that suite.
- `gofmt` clean on both touched files.