### PR TITLE
fix: use a per-user log file path instead of a shared /tmp path

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -280,6 +280,24 @@ func main() {
 	}
 }
 
+// defaultLogFilePath returns a per-user path for kubectl-ai's log file,
+// under the user's cache directory (e.g. ~/.cache/kubectl-ai on Linux,
+// %LocalAppData% on Windows). The previous fixed os.TempDir()-based path was
+// shared by every user on the host: whichever user's process created the
+// file first left it with permissions that made every other user's run fail
+// outright with "unable to create log: ... permission denied" (#564).
+func defaultLogFilePath() (string, error) {
+	cacheDir, err := os.UserCacheDir()
+	if err != nil {
+		return "", fmt.Errorf("getting user cache directory: %w", err)
+	}
+	dir := filepath.Join(cacheDir, "kubectl-ai")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return "", fmt.Errorf("creating log directory %q: %w", dir, err)
+	}
+	return filepath.Join(dir, "kubectl-ai.log"), nil
+}
+
 func run(ctx context.Context) error {
 	// klog setup must happen before Cobra parses any flags
 
@@ -288,7 +306,15 @@ func run(ctx context.Context) error {
 	klog.InitFlags(klogFlags)
 
 	klogFlags.Set("logtostderr", "false")
-	klogFlags.Set("log_file", filepath.Join(os.TempDir(), "kubectl-ai.log"))
+	logFilePath, err := defaultLogFilePath()
+	if err != nil {
+		// Fall back to the old shared-tmp-dir behavior rather than failing
+		// to start: a permission collision on a multi-user host is better
+		// than kubectl-ai refusing to run at all when the per-user cache
+		// directory can't be determined or created.
+		logFilePath = filepath.Join(os.TempDir(), "kubectl-ai.log")
+	}
+	klogFlags.Set("log_file", logFilePath)
 
 	defer klog.Flush()
 

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -1,0 +1,81 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestDefaultLogFilePath_IsPerUser guards against #564: a shared, fixed
+// /tmp/kubectl-ai.log path means the first user on a shared/edge node to run
+// kubectl-ai creates the file with permissions that block every other user,
+// who then fails outright with "unable to create log: ... permission
+// denied" instead of getting their own log.
+func TestDefaultLogFilePath_IsPerUser(t *testing.T) {
+	path, err := defaultLogFilePath()
+	if err != nil {
+		t.Fatalf("defaultLogFilePath() returned error: %v", err)
+	}
+
+	if strings.HasPrefix(filepath.Clean(path), filepath.Clean(os.TempDir())) {
+		t.Errorf("defaultLogFilePath() = %q, resolves under the shared system temp dir (os.TempDir()); "+
+			"on a multi-user host this is the exact path collision from #564", path)
+	}
+
+	if filepath.Base(path) != "kubectl-ai.log" {
+		t.Errorf("defaultLogFilePath() = %q, want a file named kubectl-ai.log", path)
+	}
+
+	// The parent directory must exist (and be creatable) so klog can open
+	// the log file on first run, the same guarantee os.TempDir() gave for
+	// free.
+	if _, err := os.Stat(filepath.Dir(path)); err != nil {
+		t.Errorf("defaultLogFilePath() parent directory not usable: %v", err)
+	}
+}
+
+// TestDefaultLogFilePath_TwoUsersGetDifferentPaths simulates two different
+// users (distinct HOME/USERPROFILE) and asserts they resolve to different
+// log file paths, so one user's file permissions can never block another's.
+func TestDefaultLogFilePath_TwoUsersGetDifferentPaths(t *testing.T) {
+	// os.UserCacheDir() reads $HOME (via $XDG_CACHE_HOME) on Linux/macOS but
+	// %LocalAppData% directly on Windows — set whichever this platform's
+	// implementation actually consults, for each simulated user.
+	setSimulatedUserCacheEnv := func(home string) {
+		t.Setenv("HOME", home)
+		t.Setenv("XDG_CACHE_HOME", "")
+		t.Setenv("USERPROFILE", home)
+		t.Setenv("LocalAppData", filepath.Join(home, "AppData", "Local"))
+	}
+
+	setSimulatedUserCacheEnv(t.TempDir())
+	pathA, err := defaultLogFilePath()
+	if err != nil {
+		t.Fatalf("defaultLogFilePath() for user A returned error: %v", err)
+	}
+
+	setSimulatedUserCacheEnv(t.TempDir())
+	pathB, err := defaultLogFilePath()
+	if err != nil {
+		t.Fatalf("defaultLogFilePath() for user B returned error: %v", err)
+	}
+
+	if pathA == pathB {
+		t.Errorf("two different users resolved to the same log path %q — the #564 collision", pathA)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #564. kubectl-ai's klog setup wrote to a fixed, shared path: `filepath.Join(os.TempDir(), "kubectl-ai.log")`. On a shared/edge node with multiple users, whichever user runs kubectl-ai first creates that file with permissions that block every other user, who then fails outright:

```
log: exiting because of error: log: unable to create log: open /tmp/kubectl-ai.log: permission denied
```

## Fix

Added `defaultLogFilePath()`, resolving to `<user cache dir>/kubectl-ai/kubectl-ai.log` via `os.UserCacheDir()` — `~/.cache/kubectl-ai` on Linux, `~/Library/Caches/kubectl-ai` on macOS, `%LocalAppData%\kubectl-ai` on Windows — which is inherently per-user, so this class of collision can't happen. Falls back to the previous shared-tmp-dir path if the cache directory can't be determined or created (rather than failing to start), so environments where `os.UserCacheDir()` doesn't resolve keep working exactly as before.

This follows the same "cache directory over shared tmp" idea floated in the issue thread, using `os.UserCacheDir()` (already the right primitive here — the repo's existing `os.UserConfigDir()` usage for config files is the analogous pattern) rather than the two alternatives discussed (home dir directly, or a per-UID filename in `/tmp`), since it needs no UID lookup and doesn't put a log file directly in `$HOME`.

## Testing Plan

- Added `cmd/main_test.go`:
  - `TestDefaultLogFilePath_IsPerUser`: asserts the resolved path is not under `os.TempDir()` and that its parent directory is created and usable.
  - `TestDefaultLogFilePath_TwoUsersGetDifferentPaths`: simulates two different users (distinct `HOME`/`USERPROFILE`/`LocalAppData`) and asserts they resolve to different log paths — the actual #564 collision.
- Verified RED: both tests fail to compile against pre-fix code (`defaultLogFilePath` doesn't exist).
- Verified GREEN: both pass with the fix; full `cmd` package test suite (`go test ./...`) green.
- `go vet ./...` and `gofmt` clean on both touched files.