### PR TITLE
Make resize-pvc eval portable across cluster types

### DIFF
--- a/dev/ci/periodics/run-evals.sh
+++ b/dev/ci/periodics/run-evals.sh
@@ -23,6 +23,13 @@ curl -sSL https://raw.githubusercontent.com/GoogleCloudPlatform/kubectl-ai/main/
 K8S_AI_BENCH_SRC="${REPO_ROOT}/.build/k8s-ai-bench-src"
 rm -rf "${K8S_AI_BENCH_SRC}"
 git clone https://github.com/gke-labs/k8s-ai-bench "${K8S_AI_BENCH_SRC}"
+
+EVAL_TASK_OVERRIDES_DIR="${REPO_ROOT}/eval-task-overrides"
+if [[ -d "${EVAL_TASK_OVERRIDES_DIR}" ]]; then
+    echo "Applying kubectl-ai eval task overrides from ${EVAL_TASK_OVERRIDES_DIR}"
+    cp -R "${EVAL_TASK_OVERRIDES_DIR}/." "${K8S_AI_BENCH_SRC}/tasks/"
+fi
+
 cd "${K8S_AI_BENCH_SRC}"
 GOWORK=off go build -o "${BINDIR}/k8s-ai-bench" .
 

--- a/eval-task-overrides/resize-pvc/artifacts/storage-class.yaml
+++ b/eval-task-overrides/resize-pvc/artifacts/storage-class.yaml
@@ -1,0 +1,8 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: resize-pvc-expandable
+provisioner: kubernetes.io/no-provisioner
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+reclaimPolicy: Retain

--- a/eval-task-overrides/resize-pvc/artifacts/storage-pod.yaml
+++ b/eval-task-overrides/resize-pvc/artifacts/storage-pod.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: storage-pod
+  namespace: resize-pv
+spec:
+  volumes:
+    - name: my-storage
+      persistentVolumeClaim:
+        claimName: storage-pvc
+  containers:
+    - name: storage-user
+      image: nginx:alpine
+      volumeMounts:
+        - name: my-storage
+          mountPath: /usr/share/nginx/html
+      ports:
+        - containerPort: 80

--- a/eval-task-overrides/resize-pvc/artifacts/storage-pv.yaml
+++ b/eval-task-overrides/resize-pvc/artifacts/storage-pv.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: resize-pvc-storage-pv
+spec:
+  capacity:
+    storage: 10Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: resize-pvc-expandable
+  claimRef:
+    namespace: resize-pv
+    name: storage-pvc
+  hostPath:
+    path: /tmp/k8s-ai-bench-resize-pvc
+    type: DirectoryOrCreate

--- a/eval-task-overrides/resize-pvc/artifacts/storage-pvc.yaml
+++ b/eval-task-overrides/resize-pvc/artifacts/storage-pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: storage-pvc
+  namespace: resize-pv
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: resize-pvc-expandable

--- a/eval-task-overrides/resize-pvc/cleanup.sh
+++ b/eval-task-overrides/resize-pvc/cleanup.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+kubectl delete namespace resize-pv --ignore-not-found=true

--- a/eval-task-overrides/resize-pvc/setup.sh
+++ b/eval-task-overrides/resize-pvc/setup.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+kubectl delete namespace resize-pv --ignore-not-found
+kubectl create namespace resize-pv
+
+# Apply a self-contained expandable storage setup that works on any cluster
+# (KinD, GKE, minikube, etc.) without relying on the default StorageClass.
+kubectl apply -f artifacts/storage-class.yaml
+kubectl apply -f artifacts/storage-pv.yaml
+kubectl apply -f artifacts/storage-pvc.yaml
+kubectl apply -f artifacts/storage-pod.yaml
+
+kubectl wait --for=condition=Ready pod/storage-pod -n resize-pv --timeout=120s

--- a/eval-task-overrides/resize-pvc/task.yaml
+++ b/eval-task-overrides/resize-pvc/task.yaml
@@ -1,0 +1,6 @@
+script:
+- prompt: "resize the storage volume to 15Gi for the storage-pod in `resize-pv` namespace"
+setup: "setup.sh"
+verifier: "verify.sh"
+cleanup: "cleanup.sh"
+difficulty: "easy"

--- a/eval-task-overrides/resize-pvc/verify.sh
+++ b/eval-task-overrides/resize-pvc/verify.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Configuration
+PVC_NAME="storage-pvc"
+NAMESPACE="resize-pv"
+EXPECTED_SIZE="15Gi"
+
+echo "Verifying PVC '$PVC_NAME' was resized to $EXPECTED_SIZE..."
+
+ACTUAL_SIZE=$(kubectl get pvc "$PVC_NAME" -n "$NAMESPACE" -o jsonpath='{.spec.resources.requests.storage}')
+
+if [ -z "$ACTUAL_SIZE" ]; then
+  echo "Error: Could not read requested storage size for PVC '$PVC_NAME'."
+  kubectl describe pvc "$PVC_NAME" -n "$NAMESPACE"
+  exit 1
+fi
+
+if [ "$ACTUAL_SIZE" != "$EXPECTED_SIZE" ]; then
+  echo "FAILURE: PVC '$PVC_NAME' request size is '$ACTUAL_SIZE', expected '$EXPECTED_SIZE'."
+  kubectl get pvc "$PVC_NAME" -n "$NAMESPACE" -o yaml
+  exit 1
+fi
+
+echo "SUCCESS: PVC '$PVC_NAME' requested storage was updated to $EXPECTED_SIZE."
+
+# If the cluster supports volume expansion, confirm the status reflects the new size.
+STATUS_SIZE=$(kubectl get pvc "$PVC_NAME" -n "$NAMESPACE" -o jsonpath='{.status.capacity.storage}' 2>/dev/null || true)
+if [ -n "$STATUS_SIZE" ] && [ "$STATUS_SIZE" = "$EXPECTED_SIZE" ]; then
+  echo "SUCCESS: PVC status capacity also reports $EXPECTED_SIZE."
+elif [ -n "$STATUS_SIZE" ]; then
+  echo "NOTE: PVC status capacity is '$STATUS_SIZE'. Spec resize succeeded; backend expansion may be cluster-dependent."
+fi


### PR DESCRIPTION
## Summary
- Add a portable resize-pvc eval task override with a self-contained expandable StorageClass and static hostPath PV
- Verify the PVC requested size instead of waiting for PV capacity expansion, which is cluster-provisioner dependent
- Apply kubectl-ai eval task overrides when running dev/ci/periodics/run-evals.sh

Fixes #531

## Context
The upstream resize-pvc task relied on the default standard StorageClass and checked PersistentVolume capacity. That fails on KinD and other clusters where the default provisioner does not support volume expansion (see discussion in #319).

This override keeps the same user-facing prompt while making setup and verification portable.

## Test plan
- [ ] Run resize-pvc eval against a KinD cluster via run-evals.sh
- [ ] Confirm setup creates the expandable storage resources and the verifier passes after patching the PVC to 15Gi
- [ ] Confirm overrides are copied into the cloned k8s-ai-bench tasks directory before eval execution
